### PR TITLE
Updated the logo `alt` attribute on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="babel" src="assets/logo_with_text.png" width="546">
+  <img alt="Rome, logo of an ancient Greek spartan helmet" src="assets/logo_with_text.png" width="546">
 </p>
 
 **Rome** is an experimental JavaScript toolchain. It includes a compiler, linter, formatter, bundler, testing framework and more. It aims to be a comprehensive tool for anything related to the processing of JavaScript source code.


### PR DESCRIPTION
The logo used to have an `alt` attribute from a previous project.
The new `alt` attribute includes the name of the project and a description of the logo taken from the history section of the README.md.