### PR TITLE
[@romejs] CompilerLinter.ts: fix invalid json syntax in message

### DIFF
--- a/packages/@romejs/core/master/linter/CompilerLinter.ts
+++ b/packages/@romejs/core/master/linter/CompilerLinter.ts
@@ -78,7 +78,7 @@ export default class CompilerLinter {
                 printer.addDiagnostic({
                   category: '',
                   message:
-                    'Files excluded from linting as it's not enabled. Add `lint: {"enabled": true}`',
+                    'Files excluded from linting as it\'s not enabled. Add `lint: {"enabled": true}`',
                   ...consumer.getDiagnosticPointer(),
                 });
               } else {

--- a/packages/@romejs/core/master/linter/CompilerLinter.ts
+++ b/packages/@romejs/core/master/linter/CompilerLinter.ts
@@ -78,7 +78,7 @@ export default class CompilerLinter {
                 printer.addDiagnostic({
                   category: '',
                   message:
-                    "Files excluded from linting as it's not enabled. Add `lint: {\"enabled\": true}`",
+                    'Files excluded from linting as it's not enabled. Add `lint: {"enabled": true}`',
                   ...consumer.getDiagnosticPointer(),
                 });
               } else {

--- a/packages/@romejs/core/master/linter/CompilerLinter.ts
+++ b/packages/@romejs/core/master/linter/CompilerLinter.ts
@@ -78,7 +78,7 @@ export default class CompilerLinter {
                 printer.addDiagnostic({
                   category: '',
                   message:
-                    "Files excluded from linting as it's not enabled. Add `lint: {enabled: true}`",
+                    "Files excluded from linting as it's not enabled. Add `lint: {\"enabled\": true}`",
                   ...consumer.getDiagnosticPointer(),
                 });
               } else {


### PR DESCRIPTION
I've tried `./scripts/dev-rome lint` command, and then I got this error message on console.
But json syntax must be double quote key string like `{"enabled": true}`.

I added escaped double quotes at the key string.

```js
"Files excluded from linting as it's not enabled. Add `lint: {\"enabled\": true}`"
```

Thanks 🤗

