### PR TITLE
Fix error: The server->client event "reporterRemoteToLocalMessage"

### DIFF
--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -457,10 +457,6 @@ export default class Master {
       useRemoteProgressBars: useRemoteReporter,
     });
 
-    bridge.reporterRemoteServerMessage.subscribe(msg => {
-      bridge.reporterRemoteServerMessage.send(msg);
-    });
-
     bridge.reporterRemoteClientMessage.subscribe(msg => {
       reporter.receivedRemoteServerMessage(msg);
     });


### PR DESCRIPTION
Hi i try run `rome start` and get error

```✔ Connected to daemon
✔ Started daemon!
Done in 0.26s.
[Error: The server->client event "reporterRemoteToLocalMessage" cannot be subscribed by a client bridge
  Failed to generate stacktrace: ENOENT: no such file or directory, open '/Users/User/Downloads/sa/rome.cjs.map'] Promise {
  <rejected> [Error: The server->client event "reporterRemoteToLocalMessage" cannot be subscribed by a client bridge
    Failed to generate stacktrace: ENOENT: no such file or directory, open '/Users/User/Downloads/sa/rome.cjs.map']```