### PR TITLE
Enable jsx with pragma

### DIFF
--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/input.mjs
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/input.mjs
@@ -1,0 +1,6 @@
+/** @jsx mdx */
+import {mdx} from '@mdx-js/preact';
+
+export default function MDXContent() {
+  return <h1>hi</h1>;
+}

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
@@ -1,40 +1,321 @@
 Program {
-  diagnostics: Array []
   directives: Array []
   filename: '..'
   hasHoistedVars: false
-  mtime: 1_582_837_084_392.2607
-  sourceType: 'module'
-  comments: Array [CommentBlock {value: '* @jsx mdx '}]
-  syntax: Array ['jsx']
+  interpreter: undefined
+  mtime: undefined
+  sourceType: 'script'
+  syntax: Array [
+    'jsx'
+    'flow'
+  ]
+  loc: Object {
+    filename: '..'
+    end: Object {
+      column: 0
+      index: 116
+      line: 7
+    }
+    start: Object {
+      column: 0
+      index: 0
+      line: 1
+    }
+  }
+  comments: Array [
+    CommentBlock {
+      value: '* @jsx mdx '
+      loc: Object {
+        filename: '..'
+        end: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
+      }
+    }
+  ]
+  diagnostics: Array [
+    Object {
+      category: 'parse/js'
+      filename: '..'
+      message: '<emphasis>import</emphasis> and <emphasis>export</emphasis> can only appear in a module'
+      mtime: undefined
+      origins: Array [Object {category: 'js-parser'}]
+      end: Object {
+        column: 35
+        index: 51
+        line: 2
+      }
+      start: Object {
+        column: 0
+        index: 16
+        line: 2
+      }
+      advice: Array [
+        log {
+          category: 'info'
+          message: 'Change the extension to <emphasis>.mjs</emphasis> to turn this file into a module'
+        }
+        log {
+          category: 'info'
+          message: 'Add <emphasis>"type": "module"</emphasis> to your <emphasis>package.json</emphasis>'
+        }
+      ]
+    }
+  ]
   body: Array [
     ImportDeclaration {
-      source: StringLiteral {value: '@mdx-js/preact'}
+      importKind: undefined
+      loc: Object {
+        filename: '..'
+        end: Object {
+          column: 35
+          index: 51
+          line: 2
+        }
+        start: Object {
+          column: 0
+          index: 16
+          line: 2
+        }
+      }
+      source: StringLiteral {
+        value: '@mdx-js/preact'
+        loc: Object {
+          filename: '..'
+          end: Object {
+            column: 34
+            index: 50
+            line: 2
+          }
+          start: Object {
+            column: 18
+            index: 34
+            line: 2
+          }
+        }
+      }
       specifiers: Array [
         ImportSpecifier {
-          imported: Identifier {name: 'mdx'}
-          local: ImportSpecifierLocal {name: BindingIdentifier {name: 'mdx'}}
+          loc: Object {
+            filename: '..'
+            end: Object {
+              column: 11
+              index: 27
+              line: 2
+            }
+            start: Object {
+              column: 8
+              index: 24
+              line: 2
+            }
+          }
+          imported: Identifier {
+            name: 'mdx'
+            loc: Object {
+              filename: '..'
+              end: Object {
+                column: 11
+                index: 27
+                line: 2
+              }
+              start: Object {
+                column: 8
+                index: 24
+                line: 2
+              }
+            }
+          }
+          local: ImportSpecifierLocal {
+            name: BindingIdentifier {
+              name: 'mdx'
+              loc: Object {
+                filename: '..'
+                end: Object {
+                  column: 11
+                  index: 27
+                  line: 2
+                }
+                start: Object {
+                  column: 8
+                  index: 24
+                  line: 2
+                }
+              }
+            }
+            importKind: undefined
+            loc: Object {
+              filename: '..'
+              end: Object {
+                column: 11
+                index: 27
+                line: 2
+              }
+              start: Object {
+                column: 8
+                index: 24
+                line: 2
+              }
+            }
+          }
         }
       ]
     }
     ExportDefaultDeclaration {
+      loc: Object {
+        filename: '..'
+        end: Object {
+          column: 1
+          index: 115
+          line: 6
+        }
+        start: Object {
+          column: 0
+          index: 53
+          line: 4
+        }
+      }
       declaration: FunctionDeclaration {
-        id: BindingIdentifier {name: 'MDXContent'}
+        id: BindingIdentifier {
+          name: 'MDXContent'
+          loc: Object {
+            filename: '..'
+            end: Object {
+              column: 34
+              index: 87
+              line: 4
+            }
+            start: Object {
+              column: 24
+              index: 77
+              line: 4
+            }
+          }
+        }
+        loc: Object {
+          filename: '..'
+          end: Object {
+            column: 1
+            index: 115
+            line: 6
+          }
+          start: Object {
+            column: 15
+            index: 68
+            line: 4
+          }
+        }
         head: FunctionHead {
           async: false
           generator: false
           hasHoistedVars: false
           params: Array []
+          predicate: undefined
+          rest: undefined
+          returnType: undefined
+          thisType: undefined
+          typeParameters: undefined
+          loc: Object {
+            filename: '..'
+            end: Object {
+              column: 37
+              index: 90
+              line: 4
+            }
+            start: Object {
+              column: 15
+              index: 68
+              line: 4
+            }
+          }
         }
         body: BlockStatement {
           directives: Array []
+          loc: Object {
+            filename: '..'
+            end: Object {
+              column: 1
+              index: 115
+              line: 6
+            }
+            start: Object {
+              column: 37
+              index: 90
+              line: 4
+            }
+          }
           body: Array [
             ReturnStatement {
+              loc: Object {
+                filename: '..'
+                end: Object {
+                  column: 21
+                  index: 113
+                  line: 5
+                }
+                start: Object {
+                  column: 2
+                  index: 94
+                  line: 5
+                }
+              }
               argument: JSXElement {
-                name: JSXReferenceIdentifier {name: 'h1'}
+                name: JSXReferenceIdentifier {
+                  name: 'h1'
+                  loc: Object {
+                    filename: '..'
+                    end: Object {
+                      column: 12
+                      index: 104
+                      line: 5
+                    }
+                    start: Object {
+                      column: 10
+                      index: 102
+                      line: 5
+                    }
+                  }
+                }
                 attributes: Array []
                 selfClosing: false
-                children: Array [JSXText {value: 'hi'}]
+                typeArguments: undefined
+                loc: Object {
+                  filename: '..'
+                  end: Object {
+                    column: 20
+                    index: 112
+                    line: 5
+                  }
+                  start: Object {
+                    column: 9
+                    index: 101
+                    line: 5
+                  }
+                }
+                children: Array [
+                  JSXText {
+                    value: 'hi'
+                    loc: Object {
+                      filename: '..'
+                      end: Object {
+                        column: 15
+                        index: 107
+                        line: 5
+                      }
+                      start: Object {
+                        column: 13
+                        index: 105
+                        line: 5
+                      }
+                    }
+                  }
+                ]
               }
             }
           ]

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
@@ -1,0 +1,45 @@
+Program {
+  diagnostics: Array []
+  directives: Array []
+  filename: '..'
+  hasHoistedVars: false
+  mtime: 1_582_837_084_392.2607
+  sourceType: 'module'
+  comments: Array [CommentBlock {value: '* @jsx mdx '}]
+  syntax: Array ['jsx']
+  body: Array [
+    ImportDeclaration {
+      source: StringLiteral {value: '@mdx-js/preact'}
+      specifiers: Array [
+        ImportSpecifier {
+          imported: Identifier {name: 'mdx'}
+          local: ImportSpecifierLocal {name: BindingIdentifier {name: 'mdx'}}
+        }
+      ]
+    }
+    ExportDefaultDeclaration {
+      declaration: FunctionDeclaration {
+        id: BindingIdentifier {name: 'MDXContent'}
+        head: FunctionHead {
+          async: false
+          generator: false
+          hasHoistedVars: false
+          params: Array []
+        }
+        body: BlockStatement {
+          directives: Array []
+          body: Array [
+            ReturnStatement {
+              argument: JSXElement {
+                name: JSXReferenceIdentifier {name: 'h1'}
+                attributes: Array []
+                selfClosing: false
+                children: Array [JSXText {value: 'hi'}]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/jsx/basic/22/output.txt
@@ -266,7 +266,7 @@ Program {
                 }
               }
               argument: JSXElement {
-                name: JSXReferenceIdentifier {
+                name: JSXIdentifier {
                   name: 'h1'
                   loc: Object {
                     filename: '..'

--- a/packages/@romejs/js-parser/__rtests__/index.ts
+++ b/packages/@romejs/js-parser/__rtests__/index.ts
@@ -17,7 +17,7 @@ const promise = createFixtureTests((fixture, t) => {
 
   // Get the input JS
   const inputFile =
-    files.get('input.js') || files.get('input.ts') || files.get('input.tsx');
+    files.get('input.js') || files.get('input.mjs') || files.get('input.ts') || files.get('input.tsx');
   if (inputFile === undefined) {
     throw new Error(
       `The fixture ${fixture.dir} did not have an input.(js|ts|tsx)`,

--- a/packages/@romejs/js-parser/__rtests__/index.ts
+++ b/packages/@romejs/js-parser/__rtests__/index.ts
@@ -17,7 +17,10 @@ const promise = createFixtureTests((fixture, t) => {
 
   // Get the input JS
   const inputFile =
-    files.get('input.js') || files.get('input.mjs') || files.get('input.ts') || files.get('input.tsx');
+    files.get('input.js') ||
+    files.get('input.mjs') ||
+    files.get('input.ts') ||
+    files.get('input.tsx');
   if (inputFile === undefined) {
     throw new Error(
       `The fixture ${fixture.dir} did not have an input.(mjs|js|ts|tsx)`,

--- a/packages/@romejs/js-parser/__rtests__/index.ts
+++ b/packages/@romejs/js-parser/__rtests__/index.ts
@@ -20,7 +20,7 @@ const promise = createFixtureTests((fixture, t) => {
     files.get('input.js') || files.get('input.mjs') || files.get('input.ts') || files.get('input.tsx');
   if (inputFile === undefined) {
     throw new Error(
-      `The fixture ${fixture.dir} did not have an input.(js|ts|tsx)`,
+      `The fixture ${fixture.dir} did not have an input.(mjs|js|ts|tsx)`,
     );
   }
 

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -327,7 +327,7 @@ function pushComment(
     }
   }
 
-  // We should enable jsx syntax when there's a comment with @\
+  // We should enable jsx syntax when there's a comment with @\jsx
   if (opts.text.includes('@jsx')) {
     parser.syntax.add('jsx');
   }

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -327,7 +327,7 @@ function pushComment(
     }
   }
 
-  // We should enable flow syntax when there's a comment with @\flow
+  // We should enable jsx syntax when there's a comment with @\
   if (opts.text.includes('@jsx')) {
     parser.syntax.add('jsx');
   }

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -327,6 +327,11 @@ function pushComment(
     }
   }
 
+  // We should enable flow syntax when there's a comment with @\flow
+  if (opts.text.includes('@jsx')) {
+    parser.syntax.add('jsx');
+  }
+
   if (parser.isLookahead === false) {
     parser.state.comments.push(comment);
     addComment(parser, comment);


### PR DESCRIPTION
fixes #33 

In a .mjs file (or other ESModules compatible file) if there is a `@jsx` pragma at the top, enable jsx syntax. This is similar to what happens for flow with `@flow`

The tests are failing due to the .mjs file extension. Thinking about the best way to solve that, currently I added .mjs as a valid fixture extension but it seems there is some code that's "forcing" it to be read as a script instead of a module for the test purposes