### PR TITLE
[WIP/HOLD] Adds a pattern to parse NPM aliases

### DIFF
--- a/packages/@romejs/codec-js-manifest/dependencies.ts
+++ b/packages/@romejs/codec-js-manifest/dependencies.ts
@@ -18,7 +18,8 @@ export type DependencyPattern =
   | SemverPattern
   | GitPattern
   | FilePattern
-  | TagPattern;
+  | TagPattern
+  | NpmPattern;
 
 export type ManifestDependencies = Map<string, DependencyPattern>;
 
@@ -49,6 +50,12 @@ export function stringifyDependencyPattern(pattern: DependencyPattern): string {
         return pattern.url;
       } else {
         return `${pattern.url}#${pattern.hash}`;
+      }
+    case 'npm':
+      if (pattern.version === undefined) {
+        return pattern.name;
+      } else {
+        return `npm:${pattern.name}@${pattern.version}`;
       }
   }
 }
@@ -281,6 +288,25 @@ export function parseGitDependencyPattern(
   }
 }
 
+//# NPM
+
+type NpmPattern = {
+  type: 'npm'; 
+  name: string; 
+  version?: string
+};
+
+export function parseNpmDependencyPattern(pattern: string) : NpmPattern {
+  let name : string = pattern.slice(pattern.indexOf('@'), pattern.lastIndexOf('@'));
+  let version : string = pattern.slice(pattern.lastIndexOf("@") + 1);
+
+  return {
+    type: 'npm',
+    name: name,
+    version: version
+  };
+}
+
 export function parseDependencyPattern(
   consumer: Consumer,
   loose: boolean,
@@ -306,6 +332,10 @@ export function parseDependencyPattern(
 
   if (pattern.match(TAG_REGEX)) {
     return parseTag(pattern);
+  }
+
+  if(pattern.startsWith('npm:')) {
+    return parseNpmDependencyPattern(pattern);
   }
 
   return parseSemver(pattern, consumer, loose);

--- a/packages/@romejs/codec-js-manifest/dependencies.ts
+++ b/packages/@romejs/codec-js-manifest/dependencies.ts
@@ -53,7 +53,7 @@ export function stringifyDependencyPattern(pattern: DependencyPattern): string {
       }
     case 'npm':
       if (pattern.version === undefined) {
-        return pattern.name;
+        return `npm:${pattern.name}`;
       } else {
         return `npm:${pattern.name}@${pattern.version}`;
       }

--- a/packages/@romejs/codec-js-manifest/dependencies.ts
+++ b/packages/@romejs/codec-js-manifest/dependencies.ts
@@ -291,19 +291,22 @@ export function parseGitDependencyPattern(
 //# NPM
 
 type NpmPattern = {
-  type: 'npm'; 
-  name: string; 
-  version?: string
+  type: 'npm';
+  name: string;
+  version?: string;
 };
 
-export function parseNpmDependencyPattern(pattern: string) : NpmPattern {
-  let name : string = pattern.slice(pattern.indexOf('@'), pattern.lastIndexOf('@'));
-  let version : string = pattern.slice(pattern.lastIndexOf("@") + 1);
+export function parseNpmDependencyPattern(pattern: string): NpmPattern {
+  let name: string = pattern.slice(
+    pattern.indexOf('@'),
+    pattern.lastIndexOf('@'),
+  );
+  let version: string = pattern.slice(pattern.lastIndexOf('@') + 1);
 
   return {
     type: 'npm',
     name: name,
-    version: version
+    version: version,
   };
 }
 
@@ -334,7 +337,7 @@ export function parseDependencyPattern(
     return parseTag(pattern);
   }
 
-  if(pattern.startsWith('npm:')) {
+  if (pattern.startsWith('npm:')) {
     return parseNpmDependencyPattern(pattern);
   }
 


### PR DESCRIPTION
This PR adds a pattern to parse NPM aliases eg `npm:@hapi/joi@15.x.x` which were throwing an error when bundling.

@sebmck from our discussion on discord I can't figure out where I need to `parseSemverRange` on the version. Just returning the version as I did won't work?