### PR TITLE
Fix typos

### DIFF
--- a/packages/@romejs/js-compiler/__rtests__/analyzeDependencies.ts
+++ b/packages/@romejs/js-compiler/__rtests__/analyzeDependencies.ts
@@ -12,7 +12,7 @@ import {parseJS} from '@romejs/js-parser';
 import {ConstSourceType} from '@romejs/js-ast';
 import {createUnknownFilePath} from '@romejs/path';
 
-async function testAnalzeDeps(input: string, sourceType: ConstSourceType) {
+async function testAnalyzeDeps(input: string, sourceType: ConstSourceType) {
   return await analyzeDependencies({
     options: {},
     ast: parseJS({input, sourceType, path: createUnknownFilePath('unknown')}),
@@ -26,7 +26,7 @@ async function testAnalzeDeps(input: string, sourceType: ConstSourceType) {
 
 test("discovers require('module') call", async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import * as foo from 'foo';
 
@@ -41,7 +41,7 @@ test("discovers require('module') call", async t => {
 
 test('ignores require(dynamic) call', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       require(dynamic);
     `,
@@ -52,7 +52,7 @@ test('ignores require(dynamic) call', async t => {
 
 test('ignores require() call if shadowed', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       {
         function require() {}
@@ -71,7 +71,7 @@ test('ignores require() call if shadowed', async t => {
 
 test("discovers async import('foo')", async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import('./foo');
 
@@ -86,7 +86,7 @@ test("discovers async import('foo')", async t => {
 
 test('discovers local export specifiers', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export {foo, bar, yes as no};
     `,
@@ -97,7 +97,7 @@ test('discovers local export specifiers', async t => {
 
 test('discovers export declarations', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export const yes = '';
       export function foo() {}
@@ -110,7 +110,7 @@ test('discovers export declarations', async t => {
 
 test('discovers export default', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export default 'yes';
     `,
@@ -121,7 +121,7 @@ test('discovers export default', async t => {
 
 test('discovers export from', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export {foo, bar, default as no, boo as noo} from 'foobar';
     `,
@@ -132,7 +132,7 @@ test('discovers export from', async t => {
 
 test('discovers export star', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export * from 'foobar';
     `,
@@ -143,7 +143,7 @@ test('discovers export star', async t => {
 
 test('discovers import star', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import * as bar from 'foobar';
     `,
@@ -154,7 +154,7 @@ test('discovers import star', async t => {
 
 test('discovers import specifiers', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import {bar, foo, default as lol, ya as to} from 'foobar';
     `,
@@ -165,7 +165,7 @@ test('discovers import specifiers', async t => {
 
 test('discovers import default', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import bar from 'foobar';
     `,
@@ -176,7 +176,7 @@ test('discovers import default', async t => {
 
 test('discovers commonjs exports', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       exports.yes = function() {};
     `,
@@ -187,7 +187,7 @@ test('discovers commonjs exports', async t => {
 
 test('discovers commonjs module.exports', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       module.exports = function() {};
     `,
@@ -198,7 +198,7 @@ test('discovers commonjs module.exports', async t => {
 
 test('discovers top level await', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       await foobar();
     `,
@@ -209,7 +209,7 @@ test('discovers top level await', async t => {
 
 test('correctly identifies a file with es imports as es', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       import 'bar';
     `,
@@ -220,7 +220,7 @@ test('correctly identifies a file with es imports as es', async t => {
 
 test('correctly identifies a file with es exports as es', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export const foo = 'bar';
     `,
@@ -231,7 +231,7 @@ test('correctly identifies a file with es exports as es', async t => {
 
 test('correctly identifies a file with cjs exports as cjs', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       exports.foo = 'bar';
     `,
@@ -242,7 +242,7 @@ test('correctly identifies a file with cjs exports as cjs', async t => {
 
 test('correctly identifies a file with no imports or exports as unknown', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       foo();
     `,
@@ -253,7 +253,7 @@ test('correctly identifies a file with no imports or exports as unknown', async 
 
 test('disallow mix of es and cjs exports', async t => {
   t.snapshot(
-    await testAnalzeDeps(
+    await testAnalyzeDeps(
       `
       export const foo = 'bar';
       exports.bar = 'foo';

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/307/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/307/output.txt
@@ -199,7 +199,7 @@ Program {
           }
         }
         left: AssignmentIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -247,7 +247,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/308/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/308/output.txt
@@ -184,7 +184,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -215,7 +215,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -246,7 +246,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/309/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/309/output.txt
@@ -296,7 +296,7 @@ Program {
               ]
             }
             AssignmentIdentifier {
-              name: 'INVALID_PLACHOLDER'
+              name: 'INVALID_PLACEHOLDER'
               loc: Object {
                 filename: '..'
                 end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/310/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/310/output.txt
@@ -87,7 +87,7 @@ Program {
           }
         }
         left: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/393/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2015/uncategorised/393/output.txt
@@ -184,7 +184,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -215,7 +215,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -246,7 +246,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/27/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/27/output.txt
@@ -232,7 +232,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -263,7 +263,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -294,7 +294,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/32/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/32/output.txt
@@ -265,7 +265,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -296,7 +296,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -327,7 +327,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/object-default-params/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/es2017/async-functions/object-default-params/output.txt
@@ -266,7 +266,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -297,7 +297,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -328,7 +328,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-arrow-function/object-binding-pattern-01/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-arrow-function/object-binding-pattern-01/output.txt
@@ -424,7 +424,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -455,7 +455,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -486,7 +486,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.txt
@@ -539,7 +539,7 @@ Program {
                                                                                               }
                                                                                             }
                                                                                             BindingIdentifier {
-                                                                                              name: 'INVALID_PLACHOLDER'
+                                                                                              name: 'INVALID_PLACEHOLDER'
                                                                                               loc: Object {
                                                                                                 filename: '..'
                                                                                                 end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.txt
@@ -199,7 +199,7 @@ Program {
               }
             }
             left: AssignmentIdentifier {
-              name: 'INVALID_PLACHOLDER'
+              name: 'INVALID_PLACEHOLDER'
               loc: Object {
                 filename: '..'
                 end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.txt
@@ -565,7 +565,7 @@ Program {
                                                                                           }
                                                                                         }
                                                                                         AssignmentIdentifier {
-                                                                                          name: 'INVALID_PLACHOLDER'
+                                                                                          name: 'INVALID_PLACEHOLDER'
                                                                                           loc: Object {
                                                                                             filename: '..'
                                                                                             end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/optional-type/4/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/optional-type/4/output.txt
@@ -105,7 +105,7 @@ Program {
               }
             }
             init: ReferenceIdentifier {
-              name: 'INVALID_PLACHOLDER'
+              name: 'INVALID_PLACEHOLDER'
               loc: Object {
                 filename: '..'
                 end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/regression/issue-58/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/regression/issue-58/output.txt
@@ -570,7 +570,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -1059,7 +1059,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -1765,7 +1765,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -2728,7 +2728,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -3012,7 +3012,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -3296,7 +3296,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -3378,7 +3378,7 @@ Program {
             }
             params: Array [
               BindingIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -3459,7 +3459,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -3587,7 +3587,7 @@ Program {
               }
               params: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -3669,7 +3669,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -3835,7 +3835,7 @@ Program {
               }
               params: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -4176,7 +4176,7 @@ Program {
             }
           }
           alternate: ReferenceIdentifier {
-            name: 'INVALID_PLACHOLDER'
+            name: 'INVALID_PLACEHOLDER'
             loc: Object {
               filename: '..'
               end: Object {
@@ -4242,7 +4242,7 @@ Program {
               }
               params: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -4342,7 +4342,7 @@ Program {
                 }
                 params: Array [
                   BindingIdentifier {
-                    name: 'INVALID_PLACHOLDER'
+                    name: 'INVALID_PLACEHOLDER'
                     loc: Object {
                       filename: '..'
                       end: Object {
@@ -4425,7 +4425,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -4749,7 +4749,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -4830,7 +4830,7 @@ Program {
             }
             params: Array [
               BindingIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -4911,7 +4911,7 @@ Program {
           }
         }
         alternate: ReferenceIdentifier {
-          name: 'INVALID_PLACHOLDER'
+          name: 'INVALID_PLACEHOLDER'
           loc: Object {
             filename: '..'
             end: Object {
@@ -5045,7 +5045,7 @@ Program {
               }
               params: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -5173,7 +5173,7 @@ Program {
                 }
               }
               alternate: ReferenceIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -5322,7 +5322,7 @@ Program {
                     }
                     params: Array [
                       BindingIdentifier {
-                        name: 'INVALID_PLACHOLDER'
+                        name: 'INVALID_PLACEHOLDER'
                         loc: Object {
                           filename: '..'
                           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/typecasts/works-in-array-pattern/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/flow/typecasts/works-in-array-pattern/output.txt
@@ -127,7 +127,7 @@ Program {
               }
               elements: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -263,7 +263,7 @@ Program {
                   }
                   elements: Array [
                     BindingIdentifier {
-                      name: 'INVALID_PLACHOLDER'
+                      name: 'INVALID_PLACEHOLDER'
                       loc: Object {
                         filename: '..'
                         end: Object {
@@ -399,7 +399,7 @@ Program {
                 }
                 elements: Array [
                   BindingIdentifier {
-                    name: 'INVALID_PLACHOLDER'
+                    name: 'INVALID_PLACEHOLDER'
                     loc: Object {
                       filename: '..'
                       end: Object {
@@ -553,7 +553,7 @@ Program {
                     }
                     elements: Array [
                       BindingIdentifier {
-                        name: 'INVALID_PLACHOLDER'
+                        name: 'INVALID_PLACEHOLDER'
                         loc: Object {
                           filename: '..'
                           end: Object {
@@ -672,7 +672,7 @@ Program {
               }
               elements: Array [
                 BindingIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {
@@ -807,7 +807,7 @@ Program {
                   }
                   elements: Array [
                     BindingIdentifier {
-                      name: 'INVALID_PLACHOLDER'
+                      name: 'INVALID_PLACEHOLDER'
                       loc: Object {
                         filename: '..'
                         end: Object {
@@ -942,7 +942,7 @@ Program {
                 }
                 elements: Array [
                   BindingIdentifier {
-                    name: 'INVALID_PLACHOLDER'
+                    name: 'INVALID_PLACEHOLDER'
                     loc: Object {
                       filename: '..'
                       end: Object {
@@ -1095,7 +1095,7 @@ Program {
                     }
                     elements: Array [
                       BindingIdentifier {
-                        name: 'INVALID_PLACHOLDER'
+                        name: 'INVALID_PLACEHOLDER'
                         loc: Object {
                           filename: '..'
                           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/arrow-function/destructuring/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/arrow-function/destructuring/output.txt
@@ -184,7 +184,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -215,7 +215,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {
@@ -246,7 +246,7 @@ Program {
         }
       }
       expression: ReferenceIdentifier {
-        name: 'INVALID_PLACHOLDER'
+        name: 'INVALID_PLACEHOLDER'
         loc: Object {
           filename: '..'
           end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/export/declare/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/export/declare/output.txt
@@ -291,7 +291,7 @@ Program {
                 }
               }
               expression: ReferenceIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -322,7 +322,7 @@ Program {
                 }
               }
               expression: ReferenceIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -369,7 +369,7 @@ Program {
                   }
                 }
                 argument: ReferenceIdentifier {
-                  name: 'INVALID_PLACHOLDER'
+                  name: 'INVALID_PLACEHOLDER'
                   loc: Object {
                     filename: '..'
                     end: Object {

--- a/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/function/declare/output.txt
+++ b/packages/@romejs/js-parser/__rtests__/__rfixtures__/typescript/function/declare/output.txt
@@ -161,7 +161,7 @@ Program {
               }
             }
             expression: ReferenceIdentifier {
-              name: 'INVALID_PLACHOLDER'
+              name: 'INVALID_PLACEHOLDER'
               loc: Object {
                 filename: '..'
                 end: Object {
@@ -192,7 +192,7 @@ Program {
               }
             }
             expression: ReferenceIdentifier {
-              name: 'INVALID_PLACHOLDER'
+              name: 'INVALID_PLACEHOLDER'
               loc: Object {
                 filename: '..'
                 end: Object {
@@ -239,7 +239,7 @@ Program {
                 }
               }
               argument: ReferenceIdentifier {
-                name: 'INVALID_PLACHOLDER'
+                name: 'INVALID_PLACEHOLDER'
                 loc: Object {
                   filename: '..'
                   end: Object {
@@ -390,7 +390,7 @@ Program {
                       }
                     }
                     expression: ReferenceIdentifier {
-                      name: 'INVALID_PLACHOLDER'
+                      name: 'INVALID_PLACEHOLDER'
                       loc: Object {
                         filename: '..'
                         end: Object {
@@ -454,7 +454,7 @@ Program {
                     }
                   }
                   expression: ReferenceIdentifier {
-                    name: 'INVALID_PLACHOLDER'
+                    name: 'INVALID_PLACEHOLDER'
                     loc: Object {
                       filename: '..'
                       end: Object {

--- a/packages/@romejs/js-parser/parser.ts
+++ b/packages/@romejs/js-parser/parser.ts
@@ -216,7 +216,7 @@ const createJSParser = createParser(
       ): Identifier {
         return {
           type: 'Identifier',
-          name: 'INVALID_PLACHOLDER',
+          name: 'INVALID_PLACEHOLDER',
           loc: this.finishLocAt(start, end),
         };
       }
@@ -228,7 +228,7 @@ const createJSParser = createParser(
       ): StringLiteral {
         return {
           type: 'StringLiteral',
-          value: 'INVALID_PLACHOLDER',
+          value: 'INVALID_PLACEHOLDER',
           loc: this.finishLocAt(start, end),
         };
       }


### PR DESCRIPTION
Found these typos while I was working on  #68 

`INVALID_PLACHOLDER` -> `INVALID_PLACEHOLDER`
`testAnalzeDeps` -> `testAnalyzeDeps`