### PR TITLE
Update error message for missing lint config (#69)

### DIFF
--- a/packages/@romejs/core/master/linter/CompilerLinter.ts
+++ b/packages/@romejs/core/master/linter/CompilerLinter.ts
@@ -80,7 +80,7 @@ export default class CompilerLinter {
                 printer.addDiagnostic({
                   category: '',
                   message:
-                    "Files excluded from linting as it's not enabled for this project. Run `rome config enable lint` to enable it.",
+                    "Files excluded from linting as it's not enabled for this project. Run `rome config enable-category lint` to enable it.",
                   ...consumer.getDiagnosticPointer(),
                 });
               } else {


### PR DESCRIPTION
As described in #69, rome instructs the user to run `rome config enable lint` when no linting configuration is present. To generate a valid linting configuration, `rome config enable-category lint` should be run instead. This updates the CLI output to reflect that.
