### PR TITLE
Fix broken link from main readme to "getting started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ echo '{}' >rome.json
 
 This file is used to configure Rome and indicates the boundaries of your project.
 
-See [Getting Started](docs/getting-started.md) for more usage instructions.
+See [Getting Started](website/docs/introduction/getting-started.md) for more usage instructions.
 
 ## Philosophy
 


### PR DESCRIPTION
In future I assume the readme will link to a hosted website, but in the meantime just this just updates the deep link to the markdown file.

Note the tests were failing on master when I cloned and this change didn't add any failures, so I'm presuming it's ok.