### PR TITLE
Fix broken "Getting Started" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ echo '{}' >rome.json
 
 This file is used to configure Rome and indicates the boundaries of your project.
 
-See [Getting Started](docs/getting-started.md) for more usage instructions.
+See [Getting Started](website/docs/introduction/getting-started.md) for more usage instructions.
 
 ## Philosophy
 


### PR DESCRIPTION
The link provided with the text ```Getting Started``` doesn't Work. So I have updated it.

