### PR TITLE
Fix broken "Getting Started" link in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ scripts/dev-rome --help
 
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
 
-Refer to [Getting Started](../docs/getting-started.md) for more usage documentation.
+Refer to [Getting Started](../website/docs/introduction/getting-started.md) for more usage documentation.
 
 ## Testing
 

--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -20,7 +20,7 @@ $ scripts/dev-rome --help
 
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
 
-Refer to [Getting Started](../docs/getting-started.md) for more usage documentation.
+Refer to [Getting Started](../introduction/getting-started.md) for more usage documentation.
 
 ## Testing
 


### PR DESCRIPTION
This fixes two more broken "Getting Started" links in the contributing-related files.

It also might make sense to remove `CONTRIBUTING.md` since it has been added to the `website` folder (or vice versa)?