### PR TITLE
string-markup: Remove string escaping

### DIFF
--- a/packages/@romejs/string-markup/__rtests__/__rsnapshots__/parse.ts.rsnap
+++ b/packages/@romejs/string-markup/__rtests__/__rsnapshots__/parse.ts.rsnap
@@ -1,0 +1,3 @@
+{
+  "should not parse string escapes": "Array [\n  Tag {\n    name: 'filelink'\n    attributes: Map [\n      Array [\n        'target'\n        'C:\\\\Users\\\\sebmck\\\\file.ts'\n      ]\n    ]\n    children: Array []\n  }\n]"
+}

--- a/packages/@romejs/string-markup/__rtests__/parse.ts
+++ b/packages/@romejs/string-markup/__rtests__/parse.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import test from '@romejs/test';
+import {parseMarkup} from '../parse';
+
+test('should not parse string escapes', t => {
+  t.snapshot(parseMarkup('<filelink target="C:\\Users\\sebmck\\file.ts" />'));
+});

--- a/packages/@romejs/string-markup/parse.ts
+++ b/packages/@romejs/string-markup/parse.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {unescapeString} from '@romejs/string-escape';
 import {
   ParserOptions,
   createParser,
@@ -161,10 +160,9 @@ const createStringMarkupParser = createParser(
               });
             }
 
-            const unescaped = unescapeString(value);
             return {
               state,
-              token: this.finishValueToken('String', unescaped, end),
+              token: this.finishValueToken('String', value, end),
             };
           }
 


### PR DESCRIPTION
This is not necessary and prevents Windows paths from being used as attribute values. #39