### PR TITLE
support paths with spaces for development scripts

### DIFF
--- a/scripts/dev-rome
+++ b/scripts/dev-rome
@@ -19,4 +19,4 @@ echo "Building trunk"
 "$ROME_ROOT/scripts/vendor-rome" bundle "$ROME_ROOT/packages/@romejs/cli/bin/rome.ts" "$DEV_FOLDER"
 
 echo "Executing trunk"
-"$CURR_DIR/node" "$DEV_FOLDER/index.js" $@
+"$CURR_DIR/node" "$DEV_FOLDER/index.js" "$@"

--- a/scripts/node
+++ b/scripts/node
@@ -9,7 +9,7 @@ NODE_VERSION=$(node --version)
 NODE_VERSION=${NODE_VERSION%%.*}
 
 if [[ ${NODE_VERSION:1} -ge 12 ]]; then
-  node --no-warnings --max_old_space_size=4096 $@
+  node --no-warnings --max_old_space_size=4096 "$@"
 else
   echo "Expected a Node version later than v12 but got $NODE_VERSION"
   exit 1

--- a/scripts/vendor-rome
+++ b/scripts/vendor-rome
@@ -6,4 +6,4 @@
 # LICENSE file in the root directory of this source tree.
 
 CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-"$CURR_DIR/node" "$CURR_DIR/vendor/rome.cjs" $@
+"$CURR_DIR/node" "$CURR_DIR/vendor/rome.cjs" "$@"


### PR DESCRIPTION
paths are currently accidentally split by word boundaries which breaks if the path contains a space.

Quoting "$@" is usually the intended behaviour, retaining the input arguments.

See also: https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html

a bit related to developing on windows #39 