### PR TITLE
Point "Getting Started" links to website

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ scripts/dev-rome --help
 
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
 
-Refer to [Getting Started](../website/docs/introduction/getting-started.md) for more usage documentation.
+Refer to [Getting Started](https://romejs.dev/docs/introduction/getting-started/) for more usage documentation.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ echo '{}' >rome.json
 
 This file is used to configure Rome and indicates the boundaries of your project.
 
-See [Getting Started](website/docs/introduction/getting-started.md) for more usage instructions.
+See [Getting Started](https://romejs.dev/docs/introduction/getting-started/) for more usage instructions.
 
 ## Philosophy
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
       },
       links: [
         {
-          to: 'docs/introduction/getting-started',
+          to: 'docs/introduction/getting-started/',
           label: 'Docs',
           position: 'left',
         },
@@ -44,7 +44,7 @@ module.exports = {
           items: [
             {
               label: 'Getting Started',
-              to: 'docs/introduction/getting-started',
+              to: 'docs/introduction/getting-started/',
             },
           ],
         },

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -19,9 +19,7 @@ function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
   return (
-    <Layout
-      title={siteConfig.tagline}
-      description={siteConfig.tagline}>
+    <Layout title={siteConfig.tagline} description={siteConfig.tagline}>
       <header
         className={classnames(
           'hero',
@@ -48,7 +46,7 @@ function Home() {
                 'button button--primary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('docs/introduction/getting-started')}>
+              to={useBaseUrl('docs/introduction/getting-started/')}>
               Get Started&nbsp;&nbsp;→
             </Link>
           </div>


### PR DESCRIPTION
Simple PR to unify the various "Getting Started" links to point to the website instead of the repo's Markdown file.