### PR TITLE
Resolver: Add support for Node exports manifest field

### DIFF
--- a/packages/@romejs/codec-js-manifest/index.ts
+++ b/packages/@romejs/codec-js-manifest/index.ts
@@ -433,9 +433,15 @@ function normalizeExports(consumer: Consumer): boolean | ManifestExports {
   for (const [relative, value] of consumer.asMap()) {
     // If it's not a relative path then it's a platform for the root
     if (relative[0] !== '.') {
+      if (exports.size > 0) {
+        value.unexpected(
+          'Cannot mix a root conditional export with relative paths',
+        );
+      }
+
       dotConditions.set(relative, {
         consumer: value,
-        relative: createRelativeFilePath(value.asString()),
+        relative: value.asExplicitRelativeFilePath(),
       });
       continue;
     }
@@ -451,13 +457,13 @@ function normalizeExports(consumer: Consumer): boolean | ManifestExports {
     if (typeof value.asUnknown() === 'string') {
       conditions.set('default', {
         consumer: value,
-        relative: createRelativeFilePath(value.asString()),
+        relative: value.asExplicitRelativeFilePath(),
       });
     } else {
       for (const [type, relativeAlias] of value.asMap()) {
         conditions.set(type, {
           consumer: relativeAlias,
-          relative: createRelativeFilePath(relativeAlias.asString()),
+          relative: relativeAlias.asExplicitRelativeFilePath(),
         });
       }
     }
@@ -466,7 +472,7 @@ function normalizeExports(consumer: Consumer): boolean | ManifestExports {
       exports.set(createRelativeFilePath('.'), dotConditions);
     }
 
-    exports.set(createRelativeFilePath(relative), conditions);
+    exports.set(value.getKey().asExplicitRelativeFilePath(), conditions);
   }
 
   return exports;

--- a/packages/@romejs/codec-js-manifest/index.ts
+++ b/packages/@romejs/codec-js-manifest/index.ts
@@ -18,11 +18,17 @@ import {
   Manifest,
   ManifestPerson,
   ManifestRepository,
+  ManifestExports,
+  ManifestExportConditions,
 } from './types';
 import {tryParseWithOptionalOffsetPosition} from '@romejs/parser-core';
 import {normalizeName} from './name';
 import {PartialDiagnostics} from '@romejs/diagnostics';
-import {AbsoluteFilePath} from '@romejs/path';
+import {
+  AbsoluteFilePath,
+  createRelativeFilePath,
+  RelativeFilePathMap,
+} from '@romejs/path';
 import {toCamelCase} from '@romejs/string-utils';
 import {PathPatterns, parsePathPattern} from '@romejs/path-match';
 
@@ -411,6 +417,61 @@ function normalizeRepo(
   }
 }
 
+function normalizeExports(consumer: Consumer): boolean | ManifestExports {
+  if (typeof consumer.asUnknown() === 'boolean') {
+    return consumer.asBoolean();
+  }
+
+  if (!consumer.exists()) {
+    return true;
+  }
+
+  const exports: ManifestExports = new RelativeFilePathMap();
+
+  const dotConditions: ManifestExportConditions = new Map();
+
+  for (const [relative, value] of consumer.asMap()) {
+    // If it's not a relative path then it's a platform for the root
+    if (relative[0] !== '.') {
+      dotConditions.set(relative, {
+        consumer: value,
+        relative: createRelativeFilePath(value.asString()),
+      });
+      continue;
+    }
+
+    if (dotConditions.size > 0) {
+      value.unexpected(
+        'Cannot mix a root conditional export with relative paths',
+      );
+    }
+
+    const conditions: ManifestExportConditions = new Map();
+
+    if (typeof value.asUnknown() === 'string') {
+      conditions.set('default', {
+        consumer: value,
+        relative: createRelativeFilePath(value.asString()),
+      });
+    } else {
+      for (const [type, relativeAlias] of value.asMap()) {
+        conditions.set(type, {
+          consumer: relativeAlias,
+          relative: createRelativeFilePath(relativeAlias.asString()),
+        });
+      }
+    }
+
+    if (dotConditions.size > 0) {
+      exports.set(createRelativeFilePath('.'), dotConditions);
+    }
+
+    exports.set(createRelativeFilePath(relative), conditions);
+  }
+
+  return exports;
+}
+
 function normalizeBugs(
   consumer: Consumer,
   loose: boolean,
@@ -559,11 +620,8 @@ export async function normalizeManifest(
       cpu: normalizeStringArray(consumer.get('cpu'), loose),
       os: normalizeStringArray(consumer.get('os'), loose),
 
-      // Entry fields
-      browser: undefined, // normalizeString(consumer, 'browser'),
       main: normalizeString(consumer, 'main'),
-      'rome:main': normalizeString(consumer, 'rome:main'),
-      'jsnext:main': normalizeString(consumer, 'jsnext:main'),
+      exports: normalizeExports(consumer.get('exports')),
 
       // Dependency fields
       dependencies: normalizeDependencies(consumer, 'dependencies', loose),

--- a/packages/@romejs/codec-js-manifest/types.ts
+++ b/packages/@romejs/codec-js-manifest/types.ts
@@ -9,7 +9,11 @@ import {ManifestDependencies} from './dependencies';
 import {SPDXExpressionNode} from '@romejs/codec-spdx-license';
 import {SemverVersionNode} from '@romejs/codec-semver';
 import {Consumer} from '@romejs/consume';
-import {AbsoluteFilePath} from '@romejs/path';
+import {
+  AbsoluteFilePath,
+  RelativeFilePath,
+  RelativeFilePathMap,
+} from '@romejs/path';
 import {JSONObject, JSONPropertyValue} from '@romejs/codec-json';
 import {Dict} from '@romejs/typescript-helpers';
 import {PathPatterns} from '@romejs/path-match';
@@ -41,6 +45,16 @@ export type ManifestBugs = {
   email: MString;
 };
 
+export type ManifestExports = RelativeFilePathMap<ManifestExportConditions>;
+
+export type ManifestExportConditions = Map<
+  string,
+  {
+    consumer: Consumer;
+    relative: RelativeFilePath;
+  }
+>;
+
 export type Manifest = {
   name: MString;
   description: MString;
@@ -53,10 +67,8 @@ export type Manifest = {
   repository: undefined | ManifestRepository;
   bugs: undefined | ManifestBugs;
 
-  browser: MString;
   main: MString;
-  'rome:main': MString;
-  'jsnext:main': MString;
+  exports: boolean | ManifestExports;
 
   author: undefined | ManifestPerson;
   contributors: undefined | Array<ManifestPerson>;
@@ -93,10 +105,8 @@ export type JSONManifest = {
   repository: Manifest['repository'];
   bugs: Manifest['bugs'];
 
-  browser: Manifest['browser'];
   main: Manifest['main'];
-  'rome:main': Manifest['rome:main'];
-  'jsnext:main': Manifest['jsnext:main'];
+  exports: undefined | false | JSONManifestExports;
 
   author: Manifest['author'];
   contributors: Manifest['contributors'];
@@ -119,6 +129,8 @@ export type JSONManifest = {
 
   [key: string]: JSONPropertyValue;
 };
+
+export type JSONManifestExports = Dict<Dict<string> | string>;
 
 export type ManifestDefinition = {
   path: AbsoluteFilePath;

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -47,7 +47,6 @@ import {
   RelativeFilePath,
   URLFilePath,
   createUnknownFilePath,
-  createRelativeFilePath,
   AbsoluteFilePath,
   createURLFilePath,
   createAbsoluteFilePath,

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -42,7 +42,16 @@ import {
 } from '@romejs/ob1';
 import {isValidIdentifierName} from '@romejs/js-ast-utils';
 import {escapeString} from '@romejs/string-escape';
-import {UnknownFilePath} from '@romejs/path';
+import {
+  UnknownFilePath,
+  RelativeFilePath,
+  URLFilePath,
+  createUnknownFilePath,
+  createRelativeFilePath,
+  AbsoluteFilePath,
+  createURLFilePath,
+  createAbsoluteFilePath,
+} from '@romejs/path';
 
 type UnexpectedConsumerOptions = {
   loc?: SourceLocation;
@@ -99,6 +108,7 @@ export default class Consumer {
     this.propertyMetadata = opts.propertyMetadata;
     this.usedNames = new Set();
     this.forkCache = new Map();
+    this.forceDiagnosticTarget = opts.forceDiagnosticTarget;
 
     // See shouldDispatchUnexpected for explanation
     this.hasHandledUnexpected = false;
@@ -118,6 +128,7 @@ export default class Consumer {
   usedNames: Set<string>;
   forkCache: Map<string, Consumer>;
   hasHandledUnexpected: boolean;
+  forceDiagnosticTarget: undefined | ConsumeSourceLocationRequestTarget;
 
   async capture<T>(
     callback: (consumer: Consumer) => Promise<T> | T,
@@ -176,6 +187,10 @@ export default class Consumer {
   getDiagnosticPointer(
     target: ConsumeSourceLocationRequestTarget = 'all',
   ): undefined | DiagnosticPointer {
+    const {forceDiagnosticTarget} = this;
+    if (forceDiagnosticTarget !== undefined) {
+      target = forceDiagnosticTarget;
+    }
     return this.context.getDiagnosticPointer(this.keyPath, target);
   }
 
@@ -228,7 +243,14 @@ export default class Consumer {
     };
   }
 
-  getKey(): ConsumeKey {
+  getKey(): Consumer {
+    return this.clone({
+      forceDiagnosticTarget: 'key',
+      value: this.getParentKey(),
+    });
+  }
+
+  getParentKey(): ConsumeKey {
     return this.keyPath[this.keyPath.length - 1];
   }
 
@@ -464,7 +486,7 @@ export default class Consumer {
 
     // Mutate the parent
     const parentObj = parent.asUnknownObject();
-    const key = this.getKey();
+    const key = this.getParentKey();
     parentObj[String(key)] = value;
     parent.setValue(parentObj);
 
@@ -864,6 +886,55 @@ export default class Consumer {
 
     this.unexpected('Expected a bigint');
     return BigInt('0');
+  }
+
+  // PATHS
+
+  asURLFilePath(): URLFilePath {
+    const path = this.asUnknownFilePath();
+    if (path.isURL()) {
+      return path.assertURL();
+    } else {
+      this.unexpected('Expected a URL');
+      return createURLFilePath('unknown://').append(path);
+    }
+  }
+
+  asUnknownFilePath(): UnknownFilePath {
+    return createUnknownFilePath(this.asString());
+  }
+
+  asAbsoluteFilePath(): AbsoluteFilePath {
+    const path = this.asUnknownFilePath();
+    if (path.isAbsolute()) {
+      return path.assertAbsolute();
+    } else {
+      this.unexpected('Expected an absolute file path');
+      return createAbsoluteFilePath('/').append(path);
+    }
+  }
+
+  asRelativeFilePath(): RelativeFilePath {
+    const path = this.asUnknownFilePath();
+    if (path.isRelative()) {
+      return path.assertRelative();
+    } else {
+      this.unexpected('Expected a relative file path');
+      return path.toExplicitRelative();
+    }
+  }
+
+  asExplicitRelativeFilePath(): RelativeFilePath {
+    const path = this.asRelativeFilePath();
+
+    if (path.isExplicitRelative()) {
+      return path;
+    } else {
+      this.unexpected(
+        'Expected an explicit relative file path. This is one that starts with <emphasis>./</emphasis> or <emphasis>../</emphasis>',
+      );
+      return path.toExplicitRelative();
+    }
   }
 
   // NUMBER

--- a/packages/@romejs/consume/types.ts
+++ b/packages/@romejs/consume/types.ts
@@ -70,12 +70,13 @@ export type ConsumerOnDefinition = (
 export type ConsumerHandleUnexpected = (diagnostic: PartialDiagnostic) => void;
 
 export type ConsumerOptions = {
-  handleUnexpectedDiagnostic: undefined | ConsumerHandleUnexpected;
-  onDefinition: undefined | ConsumerOnDefinition;
-  propertyMetadata: undefined | ConsumePropertyMetadata;
-  filePath: undefined | UnknownFilePath;
+  handleUnexpectedDiagnostic?: ConsumerHandleUnexpected;
+  onDefinition?: ConsumerOnDefinition;
+  propertyMetadata?: ConsumePropertyMetadata;
+  filePath?: UnknownFilePath;
   objectPath: ConsumePath;
   context: ConsumeContext;
   value: unknown;
-  parent: undefined | Consumer;
+  parent?: Consumer;
+  forceDiagnosticTarget?: ConsumeSourceLocationRequestTarget;
 };

--- a/packages/@romejs/core/master/fs/resolverSuggest.ts
+++ b/packages/@romejs/core/master/fs/resolverSuggest.ts
@@ -215,6 +215,8 @@ export default function resolverSuggest(
     }
   }
 
+  // TODO check if this would have been successful if not for exports access control
+
   const source =
     querySource.source === undefined ? query.source.join() : querySource.source;
   let message = '';

--- a/packages/@romejs/js-compiler/lib/Context.ts
+++ b/packages/@romejs/js-compiler/lib/Context.ts
@@ -6,7 +6,10 @@
  */
 
 import {AnyNode, Program, ConstSourceType} from '@romejs/js-ast';
-import {SourceLocation} from '@romejs/parser-core';
+import {
+  SourceLocation,
+  extractSourceLocationRangeFromNodes,
+} from '@romejs/parser-core';
 import {
   PathOptions,
   TransformExitResult,
@@ -151,6 +154,16 @@ export default class Context {
   ) {
     return this.addLocDiagnostic(
       node === undefined ? undefined : node.loc,
+      diag,
+    );
+  }
+
+  addNodesRangeDiagnostic(
+    nodes: Array<{loc?: SourceLocation}>,
+    diag: ContextPartialDiagnostic,
+  ) {
+    return this.addLocDiagnostic(
+      extractSourceLocationRangeFromNodes(nodes),
       diag,
     );
   }

--- a/packages/@romejs/parser-core/index.ts
+++ b/packages/@romejs/parser-core/index.ts
@@ -608,3 +608,49 @@ export function createParser<T, Args extends Array<unknown>>(
     return new klass(...args);
   };
 }
+
+// Utility methods for dealing with nodes
+export function extractSourceLocationRangeFromNodes(
+  nodes: Array<{loc?: SourceLocation}>,
+): undefined | SourceLocation {
+  if (nodes.length === 0) {
+    return undefined;
+  }
+
+  let filename: undefined | string = undefined;
+  let start: undefined | Position = undefined;
+  let end: undefined | Position = undefined;
+
+  for (const node of nodes) {
+    const {loc} = node;
+    if (loc === undefined) {
+      continue;
+    }
+
+    if (start === undefined || loc.start.index < start.index) {
+      start = loc.start;
+    }
+
+    if (end === undefined || loc.end.index > end.index) {
+      end = loc.end;
+    }
+
+    if (filename === undefined) {
+      filename = loc.filename;
+    } else if (filename !== loc.filename) {
+      throw new Error(
+        `Mixed filenames in node, expected ${filename} but got ${loc.filename}`,
+      );
+    }
+  }
+
+  if (start === undefined || end === undefined) {
+    return undefined;
+  }
+
+  return {
+    filename,
+    start,
+    end,
+  };
+}

--- a/packages/@romejs/path/__rtests__/index.ts
+++ b/packages/@romejs/path/__rtests__/index.ts
@@ -17,7 +17,7 @@ const relativeTests: Array<[string, string, string]> = [
   ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '../cccc'],
   ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
   ['c:/', 'c:\\aaaa\\bbbb', 'aaaa/bbbb'],
-  ['c:/aaaa/bbbb', 'd:\\', 'D:'],
+  ['c:/aaaa/bbbb', 'd:\\', 'D:\\'],
   ['c:/aaaaa/', 'c:/aaaa/cccc', '../aaaa/cccc'],
   ['C:\\foo\\bar\\baz\\quux', 'C:\\', '../../../..'],
   ['C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json', 'bar/package.json'],
@@ -72,7 +72,7 @@ for (let i = 0; i < relativeTests.length; i++) {
         },
         out: {
           filename: relative.join(),
-          segments: relative.getSegments(),
+          segments: relative.getRawSegments(),
         },
       },
     });
@@ -83,12 +83,13 @@ for (let i = 0; i < relativeTests.length; i++) {
 
 const segmentTests: Array<[string, Array<string>]> = [
   ['./../images/test.png', ['..', 'images', 'test.png']],
+  ['foo/', ['foo', '']],
 ];
 
 for (let i = 0; i < segmentTests.length; i++) {
   const [loc, expectedSegments] = segmentTests[i];
 
   test(`segments: ${i}: ${loc}`, t => {
-    t.looksLike(createUnknownFilePath(loc).getSegments(), expectedSegments);
+    t.looksLike(createUnknownFilePath(loc).getRawSegments(), expectedSegments);
   });
 }

--- a/packages/@romejs/path/__rtests__/index.ts
+++ b/packages/@romejs/path/__rtests__/index.ts
@@ -17,7 +17,7 @@ const relativeTests: Array<[string, string, string]> = [
   ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '../cccc'],
   ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
   ['c:/', 'c:\\aaaa\\bbbb', 'aaaa/bbbb'],
-  ['c:/aaaa/bbbb', 'd:\\', 'D:\\'],
+  ['c:/aaaa/bbbb', 'd:\\', 'D:'],
   ['c:/aaaaa/', 'c:/aaaa/cccc', '../aaaa/cccc'],
   ['C:\\foo\\bar\\baz\\quux', 'C:\\', '../../../..'],
   ['C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json', 'bar/package.json'],

--- a/packages/@romejs/path/collections.ts
+++ b/packages/@romejs/path/collections.ts
@@ -61,24 +61,25 @@ class FilePathMap<FilePath extends UnknownFilePath, Value> {
   }
 
   delete(path: FilePath) {
-    const joined = path.join();
+    const joined = path.getUnique().join();
     this.joinedToValue.delete(joined);
     this.joinedToPath.delete(joined);
     this._updateSize();
   }
 
   has(path: FilePath): boolean {
-    return this.joinedToValue.has(path.join());
+    return this.joinedToValue.has(path.getUnique().join());
   }
 
   get(path: FilePath): undefined | Value {
-    return this.joinedToValue.get(path.join());
+    return this.joinedToValue.get(path.getUnique().join());
   }
 
   set(path: FilePath, value: Value) {
-    const joined = path.join();
+    const uniq = path.getUnique() as FilePath;
+    const joined = uniq.join();
     this.joinedToValue.set(joined, value);
-    this.joinedToPath.set(joined, path);
+    this.joinedToPath.set(joined, uniq);
     this._updateSize();
   }
 }

--- a/packages/@romejs/path/index.ts
+++ b/packages/@romejs/path/index.ts
@@ -272,7 +272,7 @@ class BaseFilePath<Super extends UnknownFilePath> {
   }
 
   getSegments(): PathSegments {
-    if (this.isExplicitFolder()) {
+    if (this.isExplicitFolder() && this.segments.length !== 1) {
       return this.segments.slice(0, -1);
     } else {
       return this.segments;

--- a/packages/@romejs/path/index.ts
+++ b/packages/@romejs/path/index.ts
@@ -272,7 +272,7 @@ class BaseFilePath<Super extends UnknownFilePath> {
   }
 
   getSegments(): PathSegments {
-    if (this.isExplicitFolder() && this.segments.length !== 1) {
+    if (this.isExplicitFolder() && !this.isRoot()) {
       return this.segments.slice(0, -1);
     } else {
       return this.segments;
@@ -290,14 +290,16 @@ class BaseFilePath<Super extends UnknownFilePath> {
 
     let segments: undefined | PathSegments;
 
-    if (this.isExplicitFolder()) {
-      segments = this.getSegments();
+    if (!this.isRoot()) {
+      if (this.isExplicitFolder()) {
+        segments = this.getSegments();
 
-      if (this.isExplicitRelative()) {
-        segments = segments.slice(1);
+        if (this.isExplicitRelative()) {
+          segments = segments.slice(1);
+        }
+      } else if (this.isExplicitRelative()) {
+        segments = this.getRawSegments().slice(1);
       }
-    } else if (this.isExplicitRelative()) {
-      segments = this.getRawSegments().slice(1);
     }
 
     if (segments === undefined) {

--- a/packages/@romejs/path/index.ts
+++ b/packages/@romejs/path/index.ts
@@ -361,6 +361,10 @@ class BaseFilePath<Super extends UnknownFilePath> {
 
     const items: Array<FilePathOrString> = Array.isArray(raw) ? raw : [raw];
 
+    if (items.length === 0) {
+      return this._assert();
+    }
+
     let segments: PathSegments = this.getSegments();
 
     for (const item of items) {


### PR DESCRIPTION
This PR adds support for Node Package Exports to the module resolver https://nodejs.org/api/esm.html#esm_package_exports