### PR TITLE
add noDeleteVars lint rule

### DIFF
--- a/packages/@romejs/js-compiler/__rtests__/lint.ts
+++ b/packages/@romejs/js-compiler/__rtests__/lint.ts
@@ -257,7 +257,7 @@ test('disallow var', async t => {
   ]);
 });
 
-test.only('no delete vars', async t => {
+test('no delete vars', async t => {
   const res = await testLint(
     `
     const foo = "test";
@@ -267,17 +267,17 @@ test.only('no delete vars', async t => {
     'script',
   );
 
-  console.log(res.diagnostics);
-
-  t.looksLike(res.diagnostics[1], {
-    category: 'lint/noDeleteVars',
-    message: 'Variables should not be deleted.',
-    mtime: undefined,
-    filename: 'unknown',
-    start: {index: 29, line: 3, column: 4},
-    end: {index: 39, line: 3, column: 14},
-    language: 'js',
-    sourceType: 'module',
-    origins: [{category: 'lint'}],
-  });
+  t.looksLike(res.diagnostics, [
+    {
+      category: 'lint/noDeleteVars',
+      message: 'Variables should not be deleted.',
+      mtime: undefined,
+      filename: 'unknown',
+      start: {index: 29, line: 3, column: 4},
+      end: {index: 39, line: 3, column: 14},
+      language: 'js',
+      sourceType: 'script',
+      origins: [{category: 'lint'}],
+    },
+  ]);
 });

--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -15,6 +15,7 @@ import noAsyncPromiseExecutor from './noAsyncPromiseExecutor';
 import noLabelVar from './noLabelVar';
 import noDuplicateKeys from './noDuplicateKeys';
 import disallowVar from './disallowVar';
+import noDeleteVars from './noDeleteVars';
 
 export const lintTransforms = [
   undeclaredVariables,
@@ -27,4 +28,5 @@ export const lintTransforms = [
   noLabelVar,
   noDuplicateKeys,
   disallowVar,
+  noDeleteVars,
 ];

--- a/packages/@romejs/js-compiler/transforms/lint/noDeleteVars.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noDeleteVars.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Path} from '@romejs/js-compiler';
+import {AnyNode} from '@romejs/js-ast';
+
+export default {
+  name: 'noDeleteVars',
+  enter(path: Path): AnyNode {
+    const {node} = path;
+
+    if (
+      node.type === 'UnaryExpression' &&
+      node.operator === 'delete' &&
+      node.argument.type === 'ReferenceIdentifier'
+    ) {
+      path.context.addNodeDiagnostic(node, {
+        category: 'lint/noDeleteVars',
+        message: 'Variables should not be deleted.',
+      });
+    }
+
+    return node;
+  },
+};


### PR DESCRIPTION
Address item `noDeleteVars ` on issue #94 
- Includes a test for `noDeleteVars`, assumes the parser mode is `modern`

ps: uses ES Lint `noDeleteVars` as reference

