### PR TITLE
Checks for duplicate switch case declarations

### DIFF
--- a/packages/@romejs/codec-js-regexp/index.ts
+++ b/packages/@romejs/codec-js-regexp/index.ts
@@ -165,7 +165,6 @@ export const createRegExpParser = createParser(
 
             case 'd':
             case 'D':
-            case 'b':
             case 'B':
             case 's':
             case 'S':

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -33,6 +33,7 @@ export type DiagnosticCategory =
   | 'lint/noDebugger'
   | 'lint/noDeleteVars'
   | 'lint/noDupeArgs'
+  | 'lint/noDuplicateCase'
   | 'lint/noDuplicateKeys'
   | 'lint/noEmptyCharacterClass'
   | 'lint/noExtraBooleanCast'

--- a/packages/@romejs/js-analysis/evaluators/modules/ExportLocalDeclaration.ts
+++ b/packages/@romejs/js-analysis/evaluators/modules/ExportLocalDeclaration.ts
@@ -49,7 +49,6 @@ export default function ExportLocalDeclaration(
         break;
 
       case 'TypeAliasTypeAnnotation':
-      case 'TypeAliasTypeAnnotation':
         const type = scope.getBinding(decl.id.name);
         if (type === undefined) {
           throw new Error(`Couldn't find binding type for ${decl.id.name}`);

--- a/packages/@romejs/js-ast-utils/isStatement.ts
+++ b/packages/@romejs/js-ast-utils/isStatement.ts
@@ -48,7 +48,6 @@ export default function isStatement(
     case 'FlowDeclareOpaqueType':
     case 'FlowDeclareVariable':
     case 'FlowInterfaceDeclaration':
-    case 'TypeAliasTypeAnnotation':
     case 'FlowOpaqueType':
     case 'TypeAliasTypeAnnotation':
       return true;

--- a/packages/@romejs/js-compiler/transforms/lint/__rtests__/noDuplicateCase.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/__rtests__/noDuplicateCase.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import test from '@romejs/test';
+import {
+  testLint,
+  LINT_ENABLED_FORMAT_DISABLED_CONFIG,
+} from '../../../__rtests__/lint';
+
+test('no duplicated switch cases allowed', async t => {
+  const duplicatedSwitchCase = await testLint(
+    `
+    const expr = 'a';
+    switch (expr) {
+      case 'a':
+        break;
+      case 'b':
+        break;
+      case 'c':
+        break;
+      case 'd':
+        break;
+      case 'c':
+        break;
+      default:
+        break;
+    }
+  `,
+    LINT_ENABLED_FORMAT_DISABLED_CONFIG,
+  );
+
+  t.truthy(
+    duplicatedSwitchCase.diagnostics.find(
+      d => d.category === 'lint/noDuplicateCase',
+    ),
+  );
+});

--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -17,6 +17,7 @@ import noCondAssign from './noCondAssign';
 import noDebugger from './noDebugger';
 import noDeleteVars from './noDeleteVars';
 import noDupeArgs from './noDupeArgs';
+import noDuplicateCase from './noDuplicateCase';
 import noDuplicateKeys from './noDuplicateKeys';
 import noEmptyCharacterClass from './noEmptyCharacterClass';
 import noExtraBooleanCast from './noExtraBooleanCast';
@@ -46,6 +47,7 @@ export const lintTransforms = [
   noDebugger,
   noDeleteVars,
   noDupeArgs,
+  noDuplicateCase,
   noDuplicateKeys,
   noEmptyCharacterClass,
   noExtraBooleanCast,

--- a/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.test.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.test.ts
@@ -6,10 +6,7 @@
  */
 
 import test from '@romejs/test';
-import {
-  testLint,
-  LINT_ENABLED_FORMAT_DISABLED_CONFIG,
-} from '../../../__rtests__/lint';
+import {testLint} from '../../api/lint.test';
 
 test('no duplicated switch cases allowed', async t => {
   const duplicatedSwitchCase = await testLint(
@@ -30,7 +27,6 @@ test('no duplicated switch cases allowed', async t => {
         break;
     }
   `,
-    LINT_ENABLED_FORMAT_DISABLED_CONFIG,
   );
 
   t.truthy(

--- a/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
@@ -14,7 +14,7 @@ export default {
     const {node, context} = path;
 
     if (node.type === 'SwitchStatement') {
-      let uniqueSwitchCases = new Set();
+      const uniqueSwitchCases = new Set();
 
       for (const param of node.cases) {
         if (param.test && param.test.type === 'StringLiteral') {
@@ -23,7 +23,7 @@ export default {
           if (uniqueSwitchCases.has(test.value)) {
             context.addNodeDiagnostic(param, {
               category: 'lint/noDuplicateCase',
-              message: `Duplicate case <emphasis>${test.value}</emphasis> not allowed`,
+              message: `Duplicate case <emphasis>${test.value}</emphasis> not allowed.`,
             });
           }
 

--- a/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Path} from '@romejs/js-compiler';
+import {AnyNode} from '@romejs/js-ast';
+
+export default {
+  name: 'noDuplicateCase',
+  enter(path: Path): AnyNode {
+    const {node, context} = path;
+
+    if (node.type === 'SwitchStatement') {
+      let uniqueSwitchCases = new Set();
+
+      for (const param of node.cases) {
+        const test: any = param.test;
+
+        if (test && test.value && uniqueSwitchCases.has(test.value)) {
+          context.addNodeDiagnostic(param, {
+            category: 'lint/noDuplicateCase',
+            message: `Duplicate case <emphasis>${test.value}</emphasis> not allowed`,
+          });
+        }
+
+        test && uniqueSwitchCases.add(test.value);
+      }
+    }
+
+    return node;
+  },
+};

--- a/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noDuplicateCase.ts
@@ -17,16 +17,18 @@ export default {
       let uniqueSwitchCases = new Set();
 
       for (const param of node.cases) {
-        const test: any = param.test;
+        if (param.test && param.test.type === 'StringLiteral') {
+          const {test} = param;
 
-        if (test && test.value && uniqueSwitchCases.has(test.value)) {
-          context.addNodeDiagnostic(param, {
-            category: 'lint/noDuplicateCase',
-            message: `Duplicate case <emphasis>${test.value}</emphasis> not allowed`,
-          });
+          if (uniqueSwitchCases.has(test.value)) {
+            context.addNodeDiagnostic(param, {
+              category: 'lint/noDuplicateCase',
+              message: `Duplicate case <emphasis>${test.value}</emphasis> not allowed`,
+            });
+          }
+
+          uniqueSwitchCases.add(test.value);
         }
-
-        test && uniqueSwitchCases.add(test.value);
       }
     }
 


### PR DESCRIPTION
Implements `no-duplicate-case` for the linter as part of work on issue #94 