### PR TITLE
adds noLabelVar to linter

### DIFF
--- a/packages/@romejs/js-compiler/__rtests__/lint.ts
+++ b/packages/@romejs/js-compiler/__rtests__/lint.ts
@@ -95,17 +95,23 @@ test('format enabled in project config should result in regenerated file', async
 });
 
 test('no label var', async t => {
-  const badLabel = await testLint( `
+  const badLabel = await testLint(
+    `
   const x = "test";
   x: const y = "test";
-  `, LINT_ENABLED_FORMAT_DISABLED_CONFIG);
+  `,
+    LINT_ENABLED_FORMAT_DISABLED_CONFIG,
+  );
 
   t.truthy(badLabel.diagnostics.find(d => d.category === 'lint/noLabelVar'));
 
-  const okLabel = await testLint( `
+  const okLabel = await testLint(
+    `
   const x = "test";
   z: const y = "test";
-  `, LINT_ENABLED_FORMAT_DISABLED_CONFIG);
+  `,
+    LINT_ENABLED_FORMAT_DISABLED_CONFIG,
+  );
 
   t.falsy(okLabel.diagnostics.find(d => d.category === 'lint/noLabelVar'));
 });

--- a/packages/@romejs/js-compiler/__rtests__/lint.ts
+++ b/packages/@romejs/js-compiler/__rtests__/lint.ts
@@ -93,3 +93,19 @@ test('format enabled in project config should result in regenerated file', async
   );
   t.is(res.src, "foobar('yes');\n");
 });
+
+test('no label var', async t => {
+  const badLabel = await testLint( `
+  const x = "test";
+  x: const y = "test";
+  `, LINT_ENABLED_FORMAT_DISABLED_CONFIG);
+
+  t.truthy(badLabel.diagnostics.find(d => d.category === 'lint/noLabelVar'));
+
+  const okLabel = await testLint( `
+  const x = "test";
+  z: const y = "test";
+  `, LINT_ENABLED_FORMAT_DISABLED_CONFIG);
+
+  t.falsy(okLabel.diagnostics.find(d => d.category === 'lint/noLabelVar'));
+});

--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -9,10 +9,12 @@ import defaultExportSameBasename from './defaultExportSameBasename';
 import undeclaredVariables from './undeclaredVariables';
 import unusedVariables from './unusedVariables';
 import emptyBlocks from './emptyBlocks';
+import noLabelVar from './noLabelVar';
 
 export const lintTransforms = [
   undeclaredVariables,
   defaultExportSameBasename,
   unusedVariables,
   emptyBlocks,
+  noLabelVar,
 ];

--- a/packages/@romejs/js-compiler/transforms/lint/noLabelVar.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noLabelVar.ts
@@ -13,14 +13,11 @@ export default {
   enter(path: Path): AnyNode {
     const {node, scope} = path;
 
-    if (
-      node.type === 'LabeledStatement'
-    ) {
+    if (node.type === 'LabeledStatement') {
       const name = node.label.name;
       const binding = scope.getBinding(name);
       const isDefined =
-        binding !== undefined ||
-        scope.getRootScope().isGlobal(name);
+        binding !== undefined || scope.getRootScope().isGlobal(name);
 
       if (isDefined) {
         path.context.addNodeDiagnostic(node, {

--- a/packages/@romejs/js-compiler/transforms/lint/noLabelVar.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noLabelVar.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Path} from '@romejs/js-compiler';
+import {AnyNode} from '@romejs/js-ast';
+
+export default {
+  name: 'noLabelVar',
+  enter(path: Path): AnyNode {
+    const {node, scope} = path;
+
+    if (
+      node.type === 'LabeledStatement'
+    ) {
+      const name = node.label.name;
+      const binding = scope.getBinding(name);
+      const isDefined =
+        binding !== undefined ||
+        scope.getRootScope().isGlobal(name);
+
+      if (isDefined) {
+        path.context.addNodeDiagnostic(node, {
+          category: 'lint/noLabelVar',
+          message: 'Labels should not be variable names',
+        });
+      }
+    }
+
+    return node;
+  },
+};


### PR DESCRIPTION
Adds `no-label-var` check for #94 
Maybe also check for `BROWSER` / `NODE` / `JEST` - Variables?