### PR TITLE
extending testApi with decorator

### DIFF
--- a/packages/@romejs/core/test-worker/TestWorkerRunner.ts
+++ b/packages/@romejs/core/test-worker/TestWorkerRunner.ts
@@ -13,7 +13,7 @@ import {
   INTERNAL_ERROR_LOG_ADVICE,
   createSingleDiagnosticError,
 } from '@romejs/diagnostics';
-import {TestCallback, TestOptions} from '@romejs/test';
+import {TestCallback, TestOptions, TestApiDecorator} from '@romejs/test';
 import {
   default as TestWorkerBridge,
   TestWorkerBridgeRunOptions,
@@ -243,7 +243,7 @@ export default class TestWorkerRunner {
     }
   }
 
-  async runTest(testName: string, callback: TestCallback) {
+  async runTest(testName: string, callback: TestCallback, decorator: TestApiDecorator | undefined) {
     let onTimeout: OnTimeout = () => {
       throw new Error("Promise wasn't created. Should be impossible.");
     };
@@ -254,7 +254,12 @@ export default class TestWorkerRunner {
       };
     });
 
-    const api = new TestAPI(
+    let CustomTestApi = TestAPI;
+    if (typeof decorator === 'function') {
+      CustomTestApi = decorator(TestAPI);
+    }
+
+    const api = new CustomTestApi(
       testName,
       onTimeout,
       this.snapshotManager,


### PR DESCRIPTION
I was thinking about https://github.com/facebookexperimental/rome/issues/94#issuecomment-593436846,

would it be useful that we can extending the testAPI to have custom assertions?

or prefer to have helper functions for testing like https://github.com/facebookexperimental/rome/pull/115?