### PR TITLE
Add default name for people when normalizing loose manifests

### DIFF
--- a/packages/@romejs/codec-js-manifest/index.ts
+++ b/packages/@romejs/codec-js-manifest/index.ts
@@ -312,7 +312,7 @@ function normalizePerson(consumer: Consumer, loose: boolean): ManifestPerson {
     }
 
     const person: ManifestPerson = {
-      name: consumer.get('name').asString(),
+      name: consumer.get('name').asString(loose ? '' : undefined),
       email: consumer.get('email').asStringOrVoid(),
       twitter: consumer.get('twitter').asStringOrVoid(),
       github,


### PR DESCRIPTION
I should add tests but we don't really have any for any of this package. I'll add this condition when writing them later.