### PR TITLE
fs: Make unlink safe from file deletion

### DIFF
--- a/packages/@romejs/fs/index.ts
+++ b/packages/@romejs/fs/index.ts
@@ -162,12 +162,24 @@ export function existsSync(path: AbsoluteFilePath): boolean {
 
 export function unlink(path: AbsoluteFilePath): Promise<void> {
   return promisifyVoid(path, (filename, callback) =>
-    fs.unlink(filename, callback),
+    fs.unlink(filename, err => {
+      if (err != null && err.code !== 'ENOENT') {
+        callback(err);
+      } else {
+        callback(null);
+      }
+    }),
   );
 }
 
 export function unlinkSync(path: AbsoluteFilePath): void {
-  fs.unlinkSync(path.join());
+  try {
+    fs.unlinkSync(path.join());
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
 }
 
 // createDirectory


### PR DESCRIPTION
This fixes an issue reported that's likely due to a race condition when deleting cache files.

I can't imagine any scenarios in Rome where we use `unlink` where we care if the file no longer exists, so this change suppresses them.