### PR TITLE
js-compiler: sort lint imports

### DIFF
--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -5,42 +5,44 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Add imports in alphabetical order.
 import defaultExportSameBasename from './defaultExportSameBasename';
 import disallowVar from './disallowVar';
 import emptyBlocks from './emptyBlocks';
-import sparseArray from './sparseArray';
 import noAsyncPromiseExecutor from './noAsyncPromiseExecutor';
 import noCompareNegZero from './noCompareNegZero';
 import noCondAssign from './noCondAssign';
 import noDebugger from './noDebugger';
-import noDuplicateKeys from './noDuplicateKeys';
+import noDeleteVars from './noDeleteVars';
 import noDupeArgs from './noDupeArgs';
+import noDuplicateKeys from './noDuplicateKeys';
+import noImportAssign from './noImportAssign';
 import noLabelVar from './noLabelVar';
+import noTemplateCurlyInString from './noTemplateCurlyInString';
+import noUnsafeFinally from './noUnsafeFinally';
+import sparseArray from './sparseArray';
 import undeclaredVariables from './undeclaredVariables';
 import unsafeNegation from './unsafeNegation';
 import unusedVariables from './unusedVariables';
-import noUnsafeFinally from './noUnsafeFinally';
-import noDeleteVars from './noDeleteVars';
-import noTemplateCurlyInString from './noTemplateCurlyInString';
-import noImportAssign from './noImportAssign';
 
+// Add transforms in alphabetical order.
 export const lintTransforms = [
   defaultExportSameBasename,
   disallowVar,
   emptyBlocks,
-  sparseArray,
-  noCompareNegZero,
-  unsafeNegation,
   noAsyncPromiseExecutor,
+  noCompareNegZero,
   noCondAssign,
-  noDuplicateKeys,
-  noDupeArgs,
-  noLabelVar,
-  undeclaredVariables,
-  unusedVariables,
-  noUnsafeFinally,
-  noDeleteVars,
-  noTemplateCurlyInString,
-  noImportAssign,
   noDebugger,
+  noDeleteVars,
+  noDupeArgs,
+  noDuplicateKeys,
+  noImportAssign,
+  noLabelVar,
+  noTemplateCurlyInString,
+  noUnsafeFinally,
+  sparseArray,
+  undeclaredVariables,
+  unsafeNegation,
+  unusedVariables,
 ];


### PR DESCRIPTION
Easy PR to sort the lint imports in alphabetical order so that it reduces the chance of merge conflicts and also makes visual scanning of certain imports easier.

@sebmck As a follow up, what do you think about making one directory per lint rule and co-locating the tests within each directory? `packages/@romejs/js-compiler/__rtests__/lint.ts` is growing pretty rapidly in size.