### PR TITLE
Add noInnerDeclarations lint rule

### DIFF
--- a/packages/@romejs/js-compiler/__rtests__/lint.ts
+++ b/packages/@romejs/js-compiler/__rtests__/lint.ts
@@ -758,7 +758,7 @@ test('no inner declarations', async t => {
       async default(req) {
         async function executeCode(path) {}
       },
-    });`
+    });`,
   ];
 
   for (const invalidTestCase of invalidTestCases) {

--- a/packages/@romejs/js-compiler/__rtests__/lint.ts
+++ b/packages/@romejs/js-compiler/__rtests__/lint.ts
@@ -747,6 +747,18 @@ test('no inner declarations', async t => {
         fn = function() {};
       }
     }`,
+    `class MyClass{
+      doSomething(){
+        function doSomethingElse(){}
+      }
+    }`,
+    `function createMasterCommand() {}
+    createMasterCommand({
+      description: 'TODO',
+      async default(req) {
+        async function executeCode(path) {}
+      },
+    });`
   ];
 
   for (const invalidTestCase of invalidTestCases) {

--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -14,13 +14,14 @@ import getterReturn from './getterReturn';
 import noAsyncPromiseExecutor from './noAsyncPromiseExecutor';
 import noCompareNegZero from './noCompareNegZero';
 import noCondAssign from './noCondAssign';
-import noDeleteVars from './noDeleteVars';
 import noDebugger from './noDebugger';
+import noDeleteVars from './noDeleteVars';
 import noDupeArgs from './noDupeArgs';
 import noDuplicateKeys from './noDuplicateKeys';
 import noEmptyCharacterClass from './noEmptyCharacterClass';
 import noFunctionAssign from './noFunctionAssign';
 import noImportAssign from './noImportAssign';
+import noInnerDeclarations from './noInnerDeclarations';
 import noLabelVar from './noLabelVar';
 import noTemplateCurlyInString from './noTemplateCurlyInString';
 import noUnsafeFinally from './noUnsafeFinally';
@@ -46,6 +47,7 @@ export const lintTransforms = [
   noEmptyCharacterClass,
   noFunctionAssign,
   noImportAssign,
+  noInnerDeclarations,
   noLabelVar,
   noTemplateCurlyInString,
   noUnsafeFinally,

--- a/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
@@ -24,7 +24,7 @@ export default {
           'FunctionExpression',
           'ArrowFunctionExpression',
           'ClassMethod',
-          'ObjectMethod'
+          'ObjectMethod',
         ].indexOf(path.parentPath.parentPath.node.type) < 0
       ) {
         context.addNodeDiagnostic(declaration, {

--- a/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
@@ -23,6 +23,8 @@ export default {
           'FunctionDeclaration',
           'FunctionExpression',
           'ArrowFunctionExpression',
+          'ClassMethod',
+          'ObjectMethod'
         ].indexOf(path.parentPath.parentPath.node.type) < 0
       ) {
         context.addNodeDiagnostic(declaration, {

--- a/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noInnerDeclarations.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {AnyNode} from '@romejs/js-ast';
+import {Path} from '@romejs/js-compiler';
+
+export default {
+  name: 'noInnerDeclarations',
+  enter(path: Path): AnyNode {
+    const {context, node: declaration} = path;
+
+    if (
+      declaration.type === 'FunctionDeclaration' &&
+      path.parent.type !== 'Program'
+    ) {
+      if (
+        [
+          'Program',
+          'FunctionDeclaration',
+          'FunctionExpression',
+          'ArrowFunctionExpression',
+        ].indexOf(path.parentPath.parentPath.node.type) < 0
+      ) {
+        context.addNodeDiagnostic(declaration, {
+          category: 'lint/noInnerDeclarations',
+          message: 'Function declarations in nested blocks are not permitted.',
+        });
+      }
+    }
+
+    return declaration;
+  },
+};


### PR DESCRIPTION
My attempt to add the `no-inner-declaration` lint rule.

Also, wouldn't it be nice to be able to specify the lint rules we want to check against when calling the `testLint` function? This to be able to run only the tested rule in isolation for each test and avoid the result being "polluted" by the other rules. 

What do you think?