### PR TITLE
Interactive CLI and init command fixes

### DIFF
--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -501,7 +501,7 @@ export default class Reporter {
   ): Promise<keyof Options> {
     const set = await this.select(message, {...arg, radio: true});
 
-    // Should always have at least one elemet
+    // Should always have at least one element
     return Array.from(set)[0];
   }
 
@@ -526,6 +526,16 @@ export default class Reporter {
 
     let prompt = `<brightBlack>❯</brightBlack> <emphasis>${message}</emphasis>`;
     this.logAll(prompt);
+
+    if (radio) {
+      this.info(
+        'Use arrow keys and then <emphasis>enter</emphasis> to select an option',
+      );
+    } else {
+      this.info(
+        'Use arrow keys and <emphasis>space</emphasis> to select or deselect options and then <emphasis>enter</emphasis> to confirm',
+      );
+    }
 
     const selectedOptions: Set<keyof Options> = new Set(defaults);
     let activeOption = 0;
@@ -605,6 +615,10 @@ export default class Reporter {
       const finish = () => {
         cleanup();
 
+        // Remove initial help message
+        this.writeAll(escapes.cursorUp());
+        this.writeAll(escapes.eraseLine);
+
         // Remove initial log message
         this.writeAll(escapes.cursorUp());
         this.writeAll(escapes.eraseLine);
@@ -651,11 +665,16 @@ export default class Reporter {
 
           case 'c':
             if (key.ctrl) {
+              this.warn('Cancelled by user');
               process.exit(1);
             }
             return;
 
           case 'escape':
+            this.warn('Cancelled by user');
+            process.exit(1);
+            return;
+
           case 'return':
             finish();
             return;

--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -665,12 +665,14 @@ export default class Reporter {
 
           case 'c':
             if (key.ctrl) {
+              this.spacer();
               this.warn('Cancelled by user');
               process.exit(1);
             }
             return;
 
           case 'escape':
+            this.spacer();
             this.warn('Cancelled by user');
             process.exit(1);
             return;

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -40,7 +40,7 @@ localCommands.set('init', {
     const configPath = req.client.flags.cwd.append('rome.json');
     if (await exists(configPath)) {
       reporter.error(
-        `<filelink target="${configPath.join()}" emphasis>rome.json</emphasis> file already exists`,
+        `<filelink target="${configPath.join()}" emphasis>rome.json</filelink> file already exists`,
       );
       reporter.info(
         'Use <command>rome config</command> to update an existing config',

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -13,7 +13,7 @@ import executeMain from '../common/utils/executeMain';
 import {createSingleDiagnosticError} from '@romejs/diagnostics';
 import {createAbsoluteFilePath} from '@romejs/path';
 import {Dict} from '@romejs/typescript-helpers';
-import {writeFile} from '@romejs/fs';
+import {writeFile, exists} from '@romejs/fs';
 import {VERSION} from '../common/constants';
 
 export const localCommands: Map<string, LocalCommand<any>> = new Map();
@@ -37,10 +37,18 @@ localCommands.set('init', {
 
     const config: Dict<unknown> = {};
 
+    const configPath = req.client.flags.cwd.append('rome.json');
+    if (await exists(configPath)) {
+      reporter.error(
+        `<filelink target="${configPath.join()}" emphasis>rome.json</emphasis> file already exists`,
+      );
+      reporter.info(
+        'Use <command>rome config</command> to update an existing config',
+      );
+      return false;
+    }
+
     reporter.heading('Welcome to Rome!');
-    reporter.info(
-      'Press <emphasis>space</emphasis> to select an option and <emphasis>enter</emphasis> to confirm',
-    );
 
     if (flags.defaults === false) {
       const useDefaults = await reporter.radioConfirm(
@@ -67,6 +75,9 @@ localCommands.set('init', {
         format: {
           label: 'Format',
         },
+        tests: {
+          label: 'Testing',
+        },
       },
       defaults: ['lint'],
     });
@@ -76,8 +87,10 @@ localCommands.set('init', {
     if (enabledComponents.has('format')) {
       config.format = {enabled: true};
     }
+    if (enabledComponents.has('tests')) {
+      config.tests = {enabled: true};
+    }
 
-    const configPath = req.client.flags.cwd.append('rome.json');
     await writeFile(configPath, `${JSON.stringify(config, null, '  ')}\n`);
 
     reporter.success(


### PR DESCRIPTION
```
cli-reporter: Add informative prompts for key usage on all select calls
cli-reporter: In select, when pressing escape, kill the process
cli-reporter: In select, when we kill the process, also output a warning message
local init command: Add support for tests component
local init command: Error when a project already exists in the cwd
```

Resolves #161 and #162

![Screenshot from 2020-03-09 20-19-30](https://user-images.githubusercontent.com/853712/76276543-51a01d00-6243-11ea-802e-78edcb6ef720.png)
![Screenshot from 2020-03-09 20-18-43](https://user-images.githubusercontent.com/853712/76276545-5238b380-6243-11ea-90c7-b1419b676975.png)
![Screenshot from 2020-03-09 20-17-34](https://user-images.githubusercontent.com/853712/76276546-5238b380-6243-11ea-9487-e0372a524ed9.png)



