### PR TITLE
Fixing Code of Conduct link

### DIFF
--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -6,7 +6,7 @@ sidebar_label: Contributing
 
 We can use help in a bunch of areas and any help is appreciated. Our [GitHub issues](https://github.com/facebookexperimental/rome/issues) serve as a place for any discussion, whether it's bug reports, questions, project direction etc. As the project grows this policy may change.
 
-Our [Discord server](https://discord.gg/9WxHa5d) is open for help and more adhoc discussion. All activity on the Discord is still moderated and will be strictly enforced under the project's [Code of Conduct](./CODE_OF_CONDUCT.md).
+Our [Discord server](https://discord.gg/9WxHa5d) is open for help and more adhoc discussion. All activity on the Discord is still moderated and will be strictly enforced under the project's [Code of Conduct](https://github.com/facebookexperimental/rome/blob/master/.github/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 


### PR DESCRIPTION
The current `Code of Conduct` link is broken. I was initially going to move back directories and navigate to `CODE_OF_CONDUCT.md` but I felt that linking `https://github.com/facebookexperimental/rome/blob/master/.github/CODE_OF_CONDUCT.md` would be a better solution

Let me know if there's any preference! 👍 