### PR TITLE
package.json: add "engines": {"node": ">=12.0.0"}

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rome-root",
   "license": "MIT",
   "version": "0.0.2",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "//": "Look! No deps!",
   "dependencies": {},
   "///": "Only used for static type checking",


### PR DESCRIPTION
Added requirements node version based on below doc.

[CONTRIBUTING.md getting-started](https://github.com/facebookexperimental/rome/blob/master/.github/CONTRIBUTING.md#getting-started)

I guess this is effective on common projects prevent any annoying issue report come from older node environment.  
But Rome is special about `node_modules`, don't need run `yarn install` though. 😅

```
// run yarn install with node v10.15.3
ryota.murakami@ryotas-MacBook-Pro ~/f/rome> yarn install
yarn install v1.22.0
[1/5] 🔍  Validating package.json...
error rome-root@0.0.2: The engine "node" is incompatible with this module. Expected version ">=12.0.0". Got "10.15.3"
error Found incompatible module.
```

Anyway I think better than nothing this is, thanks! 🙏 