### PR TITLE
Add ability for DiagnosticsProcessor to ignore the unused suppression s of certain category prefixes

### DIFF
--- a/packages/@romejs/core/master/bundler/BundleRequest.ts
+++ b/packages/@romejs/core/master/bundler/BundleRequest.ts
@@ -61,6 +61,8 @@ export default class BundleRequest {
         },
       ],
     });
+    this.diagnostics.addAllowedUnusedSuppressionPrefix('lint');
+
     this.compiles = new Map();
     this.assets = new Map();
 
@@ -182,6 +184,7 @@ export default class BundleRequest {
       this.cached = false;
     }
 
+    this.diagnostics.addSuppressions(res.suppressions);
     this.diagnostics.addDiagnostics(res.diagnostics);
 
     this.compiles.set(source, res);

--- a/packages/@romejs/core/master/linter/Linter.ts
+++ b/packages/@romejs/core/master/linter/Linter.ts
@@ -28,6 +28,8 @@ export default class Linter {
       message: 'Dispatched',
     });
 
+    printer.processor.addAllowedUnusedSuppressionPrefix('bundler');
+
     const paths: AbsoluteFilePathSet = await request.getFilesFromArgs({
       getProjectIgnore: project => ({
         patterns: project.config.lint.ignore,

--- a/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
+++ b/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
@@ -20,6 +20,7 @@ import {naturalCompare} from '@romejs/string-utils';
 import {DiagnosticsError} from './errors';
 import {normalizeDiagnostics} from './normalize';
 import {add} from '@romejs/ob1';
+import {DiagnosticCategoryPrefix} from './categories';
 
 type UniquePart =
   | 'filename'
@@ -48,6 +49,7 @@ export default class DiagnosticsProcessor {
   constructor(options: CollectorOptions) {
     this.diagnostics = [];
     this.filters = [];
+    this.allowedUnusedSuppressionPrefixes = new Set();
     this.usedSuppressions = new Set();
     this.suppressions = new Set();
     this.options = options;
@@ -73,6 +75,7 @@ export default class DiagnosticsProcessor {
   includedKeys: Set<string>;
   diagnostics: PartialDiagnostics;
   filters: Array<DiagnosticFilterWithTest>;
+  allowedUnusedSuppressionPrefixes: Set<string>;
   usedSuppressions: Set<DiagnosticSuppression>;
   suppressions: Set<DiagnosticSuppression>;
   options: CollectorOptions;
@@ -93,6 +96,10 @@ export default class DiagnosticsProcessor {
 
   hasDiagnostics(): boolean {
     return this.diagnostics.length > 0;
+  }
+
+  addAllowedUnusedSuppressionPrefix(prefix: DiagnosticCategoryPrefix) {
+    this.allowedUnusedSuppressionPrefixes.add(prefix);
   }
 
   addSuppressions(suppressions: DiagnosticSuppressions) {
@@ -268,13 +275,20 @@ export default class DiagnosticsProcessor {
 
     // Add errors for remaining suppressions
     for (const suppression of this.suppressions) {
-      if (!this.usedSuppressions.has(suppression)) {
-        diagnostics.push({
-          ...suppression.loc,
-          message: 'Did not hide any error',
-          category: 'suppressions/unused',
-        });
+      if (this.usedSuppressions.has(suppression)) {
+        continue;
       }
+
+      const [categoryPrefix] = suppression.category.split('/');
+      if (this.allowedUnusedSuppressionPrefixes.has(categoryPrefix)) {
+        continue;
+      }
+
+      diagnostics.push({
+        ...suppression.loc,
+        message: 'Did not hide any error',
+        category: 'suppressions/unused',
+      });
     }
 
     return diagnostics;

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -86,3 +86,17 @@ export type DiagnosticCategory =
   | 'typeCheck/notExhaustive'
   | 'typeCheck/missingCondition'
   | 'v8/syntaxError';
+
+export type DiagnosticCategoryPrefix =
+  | 'analyzeDependencies'
+  | 'args'
+  | 'bundler'
+  | 'compiler'
+  | 'flags'
+  | 'internalError'
+  | 'lint'
+  | 'parse'
+  | 'projectManager'
+  | 'tests'
+  | 'typeCheck'
+  | 'v8';


### PR DESCRIPTION
Didn't notice that #168 removed the `addSuppressions` call. I've added it back since those suppressions could be used to hide compiler/parser diagnostics etc.

Instead, it's now possible to signal to `DiagnosticsProcessor` to ignore certain diagnostic category prefixes. We also do this to allow bundler suppressions, which would have otherwise been triggered in the linter etc.