### PR TITLE
Add og:image

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,6 +16,7 @@ module.exports = {
   organizationName: 'facebookexperimental',
   projectName: 'rome',
   themeConfig: {
+    image: 'https://romejs.dev/img/rome-logo.png',
     navbar: {
       title: 'Rome',
       logo: {


### PR DESCRIPTION
Currently, Logo is not displayed at Twitter card.
This adds `og:image`.