### PR TITLE
MasterRequest.ts: add explicit WorkerBridge type annotation

### DIFF
--- a/packages/@romejs/core/master/MasterRequest.ts
+++ b/packages/@romejs/core/master/MasterRequest.ts
@@ -536,8 +536,10 @@ export default class MasterRequest {
     filename: AbsoluteFilePath,
     opts: WorkerParseOptions,
   ): Promise<Program> {
-    return this.wrapRequestDiagnostic('parse', filename, (bridge: WorkerBridge, file) =>
-      bridge.parseJS.call({file, opts}),
+    return this.wrapRequestDiagnostic(
+      'parse',
+      filename,
+      (bridge: WorkerBridge, file) => bridge.parseJS.call({file, opts}),
     );
   }
 
@@ -572,8 +574,10 @@ export default class MasterRequest {
   async requestWorkerFormat(
     path: AbsoluteFilePath,
   ): Promise<undefined | WorkerFormatResult> {
-    return await this.wrapRequestDiagnostic('format', path, (bridge: WorkerBridge, file) =>
-      bridge.format.call({file}),
+    return await this.wrapRequestDiagnostic(
+      'format',
+      path,
+      (bridge: WorkerBridge, file) => bridge.format.call({file}),
     );
   }
 

--- a/packages/@romejs/core/master/MasterRequest.ts
+++ b/packages/@romejs/core/master/MasterRequest.ts
@@ -536,7 +536,7 @@ export default class MasterRequest {
     filename: AbsoluteFilePath,
     opts: WorkerParseOptions,
   ): Promise<Program> {
-    return this.wrapRequestDiagnostic('parse', filename, (bridge, file) =>
+    return this.wrapRequestDiagnostic('parse', filename, (bridge: WorkerBridge, file) =>
       bridge.parseJS.call({file, opts}),
     );
   }
@@ -558,7 +558,7 @@ export default class MasterRequest {
     const res = await this.wrapRequestDiagnostic(
       'lint',
       filename,
-      (bridge, file) =>
+      (bridge: WorkerBridge, file) =>
         bridge.lint.call({file, fix, prefetchedModuleSignatures}),
     );
 
@@ -572,7 +572,7 @@ export default class MasterRequest {
   async requestWorkerFormat(
     path: AbsoluteFilePath,
   ): Promise<undefined | WorkerFormatResult> {
-    return await this.wrapRequestDiagnostic('format', path, (bridge, file) =>
+    return await this.wrapRequestDiagnostic('format', path, (bridge: WorkerBridge, file) =>
       bridge.format.call({file}),
     );
   }
@@ -605,7 +605,7 @@ export default class MasterRequest {
     const compileRes = await this.wrapRequestDiagnostic(
       'compile',
       path,
-      (bridge, file) => {
+      (bridge: WorkerBridge, file) => {
         // We allow options to be passed in as undefined so we can compute an easy cache key
         if (options === undefined) {
           options = {};
@@ -647,7 +647,7 @@ export default class MasterRequest {
     const res = await this.wrapRequestDiagnostic(
       'analyzeDependencies',
       path,
-      (bridge, file) => bridge.analyzeDependencies.call({file}),
+      (bridge: WorkerBridge, file) => bridge.analyzeDependencies.call({file}),
     );
     await cache.update(path, {
       analyzeDependencies: {
@@ -675,7 +675,7 @@ export default class MasterRequest {
     const res = await this.wrapRequestDiagnostic(
       'moduleSignature',
       filename,
-      (bridge, file) => bridge.moduleSignatureJS.call({file}),
+      (bridge: WorkerBridge, file) => bridge.moduleSignatureJS.call({file}),
     );
     await cache.update(filename, {
       moduleSignature: res,


### PR DESCRIPTION
At first thank you so much publish Rome to open-source.
I'm reading code for learning what does compiler doing actually, and how to implement bunch of util tools from scratch.(Graphical CLI Interface etc)

When I reading `MasterRequest.ts` for tracking program flow, I don't understand totally about `bridge` argument that appertaining in some methods.
I'd think this type annotation is helpful for forks who unfamiliar to codebase.

Actually this is from beginner eyes, please don't hesitate close it if this is not make cense against something circumstance.

Thank you 🙇‍♂️