### PR TITLE
feat(website): improve accessibility

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -22,6 +22,7 @@
   --ifm-color-primary-light: #f8b949;
   --ifm-color-primary-lighter: #f9be57;
   --ifm-color-primary-lightest: #facf81;
+  --ifm-button-color: #000000;
   --ifm-code-font-size: 95%;
 }
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -36,9 +36,9 @@ function Home() {
               Rome is an experimental <br />
               JavaScript toolchain
             </h1>
-            <p className={styles.heroBannerSubtitle}>
+            <h2 className={styles.heroBannerSubtitle}>
               A compiler, linter, formatter, bundler, testing framework and more
-            </p>
+            </h2>
           </div>
           <div className={styles.buttons}>
             <Link

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -43,16 +43,8 @@
   line-height: var(--ifm-line-height-base);
 }
 
-.getStarted {
-  --focusColor: #000000;
-}
-
-:global(html[data-theme='dark']) .getStarted {
-  --focusColor: #FFFFFF;
-}
-
 .getStarted:focus {
-  box-shadow: 0 0 0 2px var(--focusColor);
+  box-shadow: 0 0 0 2px var(--ifm-color-content);
 }
 
 @media screen and (max-width: 966px) {

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -39,6 +39,20 @@
 .heroBannerSubtitle {
   font-size: 1.5rem;
   font-weight: var(--ifm-font-weight-semibold);
+  margin-bottom: var(--ifm-paragraph-margin-bottom);
+  line-height: var(--ifm-line-height-base);
+}
+
+.getStarted {
+  --focusColor: #000000;
+}
+
+:global(html[data-theme='dark']) .getStarted {
+  --focusColor: #FFFFFF;
+}
+
+.getStarted:focus {
+  box-shadow: 0 0 0 2px var(--focusColor);
 }
 
 @media screen and (max-width: 966px) {


### PR DESCRIPTION
Hi !

I made small improvements for the accessibility of the website :

- "Get Started" btn
	- Now has a `:focus` state which change based on the current theme
	- Changed the text color to black because of the contrast
- Changed the Hero banner subtitle to a `<h2>` for a better HTML structure
	Before the page jumped from a `<h1>` to a `<h3>`

## Get Started button

### Color Contrast

The current contrast : 

![current contrast of the website](https://i.imgur.com/d7geGBY.png)

The new one : 

![new contrast after change](https://i.imgur.com/ZQQ7Hcb.png)

### Focus

![added a focus state to the button](https://i.imgur.com/0NSQSVW.gif)

## Title

![inspect the h2 element](https://i.imgur.com/rkguXZR.png)

I hope these changes are relevant 😄 
Keep up the great work 👍 