### PR TITLE
feat(parseOperator & parseQuantifier): '{' is parsed as Operator and …

### DIFF
--- a/packages/@romejs/codec-js-regexp/index.ts
+++ b/packages/@romejs/codec-js-regexp/index.ts
@@ -736,7 +736,8 @@ export const createRegExpParser = createParser((ParserCore) =>
         case '{':
           const start = this.getPosition();
           const unmatchedQuantifier = this.parseQuantifier();
-          if (unmatchedQuantifier !== undefined) { // if quantifier is defined, then syntax error: Nothing to repeat
+          if (unmatchedQuantifier !== undefined) {
+            // if quantifier is defined, then syntax error: Nothing to repeat
             const end = this.getPosition();
             this.addDiagnostic({
               message: 'Nothing to repeat',
@@ -744,7 +745,8 @@ export const createRegExpParser = createParser((ParserCore) =>
               end,
             });
             return;
-          } else { // else quantifier is undefined & eaten tokens were restored
+          } else {
+            // else quantifier is undefined & eaten tokens were restored
             return this.parseCharacter(); // return a '{' token as a RegexpCharacter, parseBodyItem() will handle parsing of subsequent quantifiers
           }
 


### PR DESCRIPTION
…parseQuantifier correctly advances

This updates parseOperator and parseQuantifier to correctly handle {n} and {n,n} quantifiers.
parseQuantifier needs to advance to next token for the two edge cases where it finds its closing '}' token.
Otherwise, the parser would've erroneously re-create a character token for that '}' that is really just a part of the quantifier.
For the case where a {n} or {n,n} quantifier is missing a target, diagnostics will read 'Nothing to repeat'.

