### PR TITLE
[website] Removed bash command $ prefix in code blocks 

### DIFF
--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -13,9 +13,9 @@ Our [Discord server](https://discord.gg/9WxHa5d) is open for help and more adhoc
 Getting started with developing Rome is as easy as three commands. You will need Node v12 or above.
 
 ```
-$ git clone https://github.com/facebookexperimental/rome
-$ cd rome
-$ scripts/dev-rome --help
+git clone https://github.com/facebookexperimental/rome
+cd rome
+scripts/dev-rome --help
 ```
 
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
@@ -27,7 +27,7 @@ Refer to [Getting Started](../introduction/getting-started.md) for more usage do
 You can run the test suite with the following command:
 
 ```
-$ scripts/dev-rome test
+scripts/dev-rome test
 ```
 
 This will run all tests inside of any `__rtests__` directories.
@@ -37,5 +37,5 @@ This will run all tests inside of any `__rtests__` directories.
 Run TypeScript with code emitting disabled to perform a full typecheck outside the editor.
 
 ```
-$ node_modules/.bin/tsc --noEmit
+node_modules/.bin/tsc --noEmit
 ```

--- a/website/docs/introduction/getting-started.md
+++ b/website/docs/introduction/getting-started.md
@@ -13,13 +13,13 @@ as much or as little as you like.
 First, navigate into your project folder:
 
 ```bash
-$ cd my_existing_project
+cd my_existing_project
 ```
 Now, create a Rome configuration for your project. When prompted,
 use the recommended settings:
 
 ```bash
-$ rome init
+rome init
 ```
 
 ## What did we do?
@@ -47,7 +47,7 @@ The `rome run` command will run whatever file is passed to
 it. Use this command with your project's main file, for example:
 
 ```bash
-$ rome run index.js
+rome run index.js
 ```
 
 Rome is still under active development and may not be able to properly
@@ -62,7 +62,7 @@ This command will lint a file with a set of default lints and display the produc
 When ran with no arguments, all JavaScript files in a project are linted. For example:
 
 ```bash
-$ rome lint file.js
+rome lint file.js
 ```
 
 ### `compile`
@@ -70,7 +70,7 @@ $ rome lint file.js
 This command will compile a file with a set of default transforms. There is currently no options for this command to specify a subset of transforms.
 
 ```
-$ rome compile file.js
+rome compile file.js
 ```
 
 ### `parse`
@@ -78,5 +78,5 @@ $ rome compile file.js
 This command will parse a file and output a pretty formatted AST.
 
 ```
-$ rome parse file.js
+rome parse file.js
 ```

--- a/website/docs/introduction/installation.md
+++ b/website/docs/introduction/installation.md
@@ -15,19 +15,19 @@ Rome is not available via `npm` and must be installed from GitHub.
 In a folder of your choice, clone the `rome` repository:
 
 ```bash
-$ git clone https://github.com/facebookexperimental/rome
+git clone https://github.com/facebookexperimental/rome
 ```
 
 Then, navigate into it and build `rome`:
 
 ```bash
-$ cd rome; ./scripts/build-release dist
+cd rome; ./scripts/build-release dist
 ```
 
 Now, install `rome` globally:
 
 ```
-$ npm install -g ./dist/
+npm install -g ./dist/
 ```
 
 Congratulations! Rome is installed.


### PR DESCRIPTION
The installation guide and getting started guide on the website created copy-able code block that started with `$`. When actually using the docusaurus copy button, the `$` would also be copied, resulting in the user either ignoring the copy button completely or having to remove the first character of the command after pasting it in.

This change removes the `$` from the code blocks so users can copy it and directly paste it in a shell.

Quick GIF of a screencast showing the copy differences between current and this change.
![GIF](https://user-images.githubusercontent.com/32676955/77236782-efb6b000-6b7e-11ea-8710-6f7daf04598c.gif)


