### PR TITLE
Provide a hint when we can't find an export that exists as a local binding

### DIFF
--- a/packages/@romejs/core/common/types/analyzeDependencies.ts
+++ b/packages/@romejs/core/common/types/analyzeDependencies.ts
@@ -12,6 +12,7 @@ import {
   ConstProgramSyntax,
 } from '@romejs/js-ast';
 import {SourceLocation} from '@romejs/parser-core';
+import {Dict} from '@romejs/typescript-helpers';
 
 export type AnalyzeModuleType = 'es' | 'cjs' | 'unknown';
 
@@ -71,7 +72,12 @@ export type AnalyzeDependencyImportFirstUsage = Array<
   AnalyzeDependencyImportUsageItem
 >;
 
+export type AnalyzeDependencyTopLevelLocalBindings = Dict<
+  | undefined
+  | SourceLocation>;
+
 export type AnalyzeDependencyResult = {
+  topLevelLocalBindings: AnalyzeDependencyTopLevelLocalBindings;
   moduleType: AnalyzeModuleType;
   syntax: Array<ConstProgramSyntax>;
   diagnostics: Diagnostics;
@@ -82,6 +88,7 @@ export type AnalyzeDependencyResult = {
 };
 
 export const UNKNOWN_ANALYZE_DEPENDENCIES_RESULT: AnalyzeDependencyResult = {
+  topLevelLocalBindings: {},
   moduleType: 'unknown',
   syntax: [],
   diagnostics: [],

--- a/packages/@romejs/core/master/dependencies/DependencyGraph.ts
+++ b/packages/@romejs/core/master/dependencies/DependencyGraph.ts
@@ -134,10 +134,10 @@ export default class DependencyGraph {
     const stats: BundleBuddyStats = [];
 
     for (const node of this.nodes.values()) {
-      const source = node.id;
+      const source = node.uid;
 
       for (const absoluteTarget of node.relativeToAbsolutePath.values()) {
-        const target = this.getNode(absoluteTarget).id;
+        const target = this.getNode(absoluteTarget).uid;
         stats.push({
           target,
           source,
@@ -146,7 +146,7 @@ export default class DependencyGraph {
     }
 
     for (const absoluteEntry of entries) {
-      const source = this.getNode(absoluteEntry).id;
+      const source = this.getNode(absoluteEntry).uid;
       stats.push({
         source,
         target: undefined,
@@ -157,9 +157,11 @@ export default class DependencyGraph {
   }
 
   addNode(filename: AbsoluteFilePath, res: WorkerAnalyzeDependencyResult) {
-    const module = new DependencyNode(this, this.master.projectManager.getUid(
-      filename,
-    ), filename, res);
+    const module = new DependencyNode(
+      this,
+      this.master.projectManager.getFileReference(filename),
+      res,
+    );
     this.nodes.set(filename, module);
     return module;
   }

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -739,6 +739,27 @@ export const descriptions = createMessages({
           },
         }),
       }),
+
+    UNKNOWN_EXPORT_POSSIBLE_UNEXPORTED_LOCAL: (
+      name: string,
+      source: string,
+      location: DiagnosticLocation,
+    ) =>
+      ({
+        message: markup`Couldn't find export <emphasis>${name}</emphasis> in <filelink emphasis target="${source}" />`,
+        category: 'bundler/unknownExport',
+        advice: [
+          {
+            type: 'log',
+            category: 'info',
+            message: 'However we found a matching local variable in this module. Did you forget to export it?',
+          },
+          {
+            type: 'frame',
+            location,
+          },
+        ],
+      }),
   },
 
   SPDX: {

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -743,7 +743,7 @@ export const descriptions = createMessages({
     UNKNOWN_EXPORT_POSSIBLE_UNEXPORTED_LOCAL: (
       name: string,
       source: string,
-      location: DiagnosticLocation,
+      location: SourceLocation,
     ) =>
       ({
         message: markup`Couldn't find export <emphasis>${name}</emphasis> in <filelink emphasis target="${source}" />`,
@@ -752,7 +752,7 @@ export const descriptions = createMessages({
           {
             type: 'log',
             category: 'info',
-            message: 'However we found a matching local variable in this module. Did you forget to export it?',
+            message: markup`However we found a matching local variable in <filelink emphasis target="${location.filename}" />. Did you forget to export it?`,
           },
           {
             type: 'frame',

--- a/packages/@romejs/js-compiler/api/analyzeDependencies.test.md
+++ b/packages/@romejs/js-compiler/api/analyzeDependencies.test.md
@@ -11,6 +11,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     local {
       kind: 'value'
@@ -69,6 +70,21 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    foo: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 22
+        index: 23
+        line: 2
+      }
+      start: Object {
+        column: 19
+        index: 20
+        line: 2
+      }
+    }
+  }
   exports: Array [
     local {
       kind: 'value'
@@ -102,6 +118,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   dependencies: Array [
     es {
       kind: 'value'
@@ -139,6 +156,88 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
+}
+```
+
+## `defines topLevelLocalBindings`
+
+```javascript
+Object {
+  diagnostics: Array []
+  exports: Array []
+  firstTopAwaitLocation: undefined
+  importFirstUsage: Array []
+  moduleType: 'es'
+  syntax: Array []
+  topLevelLocalBindings: Object {
+    bar: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 15
+        index: 16
+        line: 2
+      }
+      start: Object {
+        column: 12
+        index: 13
+        line: 2
+      }
+    }
+    foo: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 13
+        index: 43
+        line: 3
+      }
+      start: Object {
+        column: 10
+        index: 40
+        line: 3
+      }
+    }
+  }
+  dependencies: Array [
+    es {
+      kind: 'value'
+      all: false
+      async: false
+      optional: false
+      source: 'foo'
+      loc: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 27
+          index: 28
+          line: 2
+        }
+        start: Object {
+          column: 22
+          index: 23
+          line: 2
+        }
+      }
+      names: Array [
+        value {
+          name: 'bar'
+          loc: Object {
+            filename: 'unknown'
+            end: Object {
+              column: 15
+              index: 16
+              line: 2
+            }
+            start: Object {
+              column: 12
+              index: 13
+              line: 2
+            }
+          }
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -151,6 +250,21 @@ Object {
   importFirstUsage: Array []
   moduleType: 'cjs'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    foo: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 22
+        index: 23
+        line: 2
+      }
+      start: Object {
+        column: 19
+        index: 20
+        line: 2
+      }
+    }
+  }
   diagnostics: Array [
     Object {
       origins: Array [Object {category: 'js-parser'}]
@@ -241,6 +355,21 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    yes: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 18
+        index: 43
+        line: 4
+      }
+      start: Object {
+        column: 15
+        index: 40
+        line: 4
+      }
+    }
+  }
   dependencies: Array [
     es {
       kind: 'value'
@@ -298,6 +427,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'cjs'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     local {
       kind: 'value'
@@ -337,6 +467,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'cjs'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     local {
       kind: 'value'
@@ -376,6 +507,47 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    Bar: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 22
+        index: 83
+        line: 4
+      }
+      start: Object {
+        column: 19
+        index: 80
+        line: 4
+      }
+    }
+    foo: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 25
+        index: 55
+        line: 3
+      }
+      start: Object {
+        column: 22
+        index: 52
+        line: 3
+      }
+    }
+    yes: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 22
+        index: 23
+        line: 2
+      }
+      start: Object {
+        column: 19
+        index: 20
+        line: 2
+      }
+    }
+  }
   exports: Array [
     local {
       kind: 'value'
@@ -445,6 +617,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     local {
       kind: 'value'
@@ -477,6 +650,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     external {
       kind: 'value'
@@ -655,6 +829,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     externalAll {
       kind: 'value'
@@ -710,6 +885,21 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    bar: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 16
+        index: 17
+        line: 2
+      }
+      start: Object {
+        column: 13
+        index: 14
+        line: 2
+      }
+    }
+  }
   dependencies: Array [
     es {
       kind: 'value'
@@ -763,6 +953,60 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {
+    bar: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 17
+        index: 18
+        line: 2
+      }
+      start: Object {
+        column: 14
+        index: 15
+        line: 2
+      }
+    }
+    foo: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 22
+        index: 23
+        line: 2
+      }
+      start: Object {
+        column: 19
+        index: 20
+        line: 2
+      }
+    }
+    lol: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 38
+        index: 39
+        line: 2
+      }
+      start: Object {
+        column: 35
+        index: 36
+        line: 2
+      }
+    }
+    to: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 48
+        index: 49
+        line: 2
+      }
+      start: Object {
+        column: 46
+        index: 47
+        line: 2
+      }
+    }
+  }
   dependencies: Array [
     es {
       kind: 'value'
@@ -864,6 +1108,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   dependencies: Array [
     es {
       kind: 'value'
@@ -900,6 +1145,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   exports: Array [
     local {
       kind: 'value'
@@ -969,6 +1215,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   dependencies: Array [
     es {
       kind: 'value'
@@ -1026,6 +1273,7 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
   firstTopAwaitLocation: Object {
     filename: 'unknown'
     end: Object {
@@ -1060,6 +1308,21 @@ Object {
       valueType: 'other'
     }
   ]
+  topLevelLocalBindings: Object {
+    yes: Object {
+      filename: 'unknown'
+      end: Object {
+        column: 18
+        index: 90
+        line: 7
+      }
+      start: Object {
+        column: 15
+        index: 87
+        line: 7
+      }
+    }
+  }
 }
 ```
 
@@ -1074,5 +1337,6 @@ Object {
   importFirstUsage: Array []
   moduleType: 'es'
   syntax: Array []
+  topLevelLocalBindings: Object {}
 }
 ```

--- a/packages/@romejs/js-compiler/api/analyzeDependencies.test.ts
+++ b/packages/@romejs/js-compiler/api/analyzeDependencies.test.ts
@@ -165,3 +165,10 @@ test('disallow mix of es and cjs exports', async (t) => {
       exports.bar = 'foo';
     `, 'script'));
 });
+
+test('defines topLevelLocalBindings', async (t) => {
+  t.snapshot(await testAnalyzeDeps(`
+    import {bar} from 'foo';
+    const foo = 'bar';
+  `, 'module'));
+});

--- a/packages/@romejs/js-compiler/api/analyzeDependencies/index.ts
+++ b/packages/@romejs/js-compiler/api/analyzeDependencies/index.ts
@@ -28,6 +28,7 @@ import {
   AnalyzeDependencyName,
   AnalyzeDependencyImportFirstUsage,
   AnalyzeModuleType,
+  AnalyzeDependencyTopLevelLocalBindings,
 } from '@romejs/core';
 import {descriptions} from '@romejs/diagnostics';
 
@@ -250,7 +251,15 @@ export default async function analyzeDependencies(
     });
   }
 
+  const topLevelLocalBindings: AnalyzeDependencyTopLevelLocalBindings = {};
+
+  // Get all top level bindings
+  for (const [name, binding] of context.getRootScope().evaluate(ast).getOwnBindings()) {
+    topLevelLocalBindings[name] = binding.node.loc;
+  }
+
   const res: AnalyzeDependencyResult = {
+    topLevelLocalBindings,
     moduleType,
     firstTopAwaitLocation,
     exports,


### PR DESCRIPTION
This PR adds a new `topLevelLocalBindings` property to `analyzeDependencies`. When importing from a module and we can't find the import, we check if there's a local binding with the same name and hint that they may have forgotten to export it.

I also took the liberty of cleaning up some confusing property names in `DependencyNode`.

![Screenshot from 2020-03-22 17-22-09](https://user-images.githubusercontent.com/853712/77268169-4ba63500-6c62-11ea-9290-5aca985758fa.png)

Full credit goes to @aweary who came up with this in [this tweet](https://twitter.com/aweary/status/1240386993839730688/) about a new language he's working on.