### PR TITLE
Add postinstall message

### DIFF
--- a/packages/rome/package.json
+++ b/packages/rome/package.json
@@ -9,5 +9,8 @@
   ],
   "bin": {
     "rome": "bin/rome.ts"
+  },
+  "scripts": {
+    "postinstall": "echo \"Thanks for using Rome! This space reserved for future sustainability announcements. See https://github.com/romejs/rome/pulls/X for context.\""
   }
 }


### PR DESCRIPTION
This PR adds a `postinstall` method to the, currently unreleased, `rome` npm package. Right now it's just a placeholder.

One of the tenants I listed in the README when I wrote it was:

> **Set clear expectations.** Make project intent and decisions known well in advance. Nothing should be a surprise.

This is one of the things I was thinking about when writing it. In the future we may want to advertise a link to the Rome OpenCollective if we end up having one. A lot of people evidentially hate having advertisements blasted at them in their terminal, and others may also argue the efficacy of it in the first place.

I would rather us be in the position to remove it later than not being able to add it at all.

I think having this ability is important because while I don't think I'd ever personally need funding to work on Rome, I want to build a sustainable project and in the future hopefully give others the opportunity to work on it and be compensated. The chance to ernable contributors to do that is worth annoying a few people.