### PR TITLE
Fix code gen for TSTypeAssertion and TSNonNullExpression

### DIFF
--- a/packages/@romejs/js-ast-utils/isTypeExpressionWrapperNode.ts
+++ b/packages/@romejs/js-ast-utils/isTypeExpressionWrapperNode.ts
@@ -5,10 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {AnyNode, FlowTypeCastExpression, TSAsExpression} from '@romejs/js-ast';
+import {
+  AnyNode,
+  FlowTypeCastExpression,
+  TSAsExpression,
+  TSTypeAssertion,
+  TSNonNullExpression,
+} from '@romejs/js-ast';
 
 export default function isTypeExpressionWrapperNode(
   node: AnyNode,
-): node is FlowTypeCastExpression | TSAsExpression {
-  return node.type === 'FlowTypeCastExpression' || node.type === 'TSAsExpression';
+): node is
+  | FlowTypeCastExpression
+  | TSAsExpression
+  | TSTypeAssertion
+  | TSNonNullExpression {
+  return (
+    node.type === 'FlowTypeCastExpression' || node.type === 'TSAsExpression' ||
+    node.type === 'TSTypeAssertion' || node.type === 'TSNonNullExpression'
+  );
 }

--- a/packages/@romejs/js-generator/generators/typescript/TSNonNullExpression.ts
+++ b/packages/@romejs/js-generator/generators/typescript/TSNonNullExpression.ts
@@ -11,5 +11,7 @@ import {Generator} from '@romejs/js-generator';
 export default function TSNonNullExpression(generator: Generator, node: AnyNode) {
   node = tsNonNullExpression.assert(node);
   generator.print(node.expression, node);
-  generator.token('!');
+  if (generator.options.typeAnnotations) {
+    generator.token('!');
+  }
 }

--- a/packages/@romejs/js-generator/generators/typescript/TSTypeAssertion.ts
+++ b/packages/@romejs/js-generator/generators/typescript/TSTypeAssertion.ts
@@ -10,9 +10,11 @@ import {Generator} from '@romejs/js-generator';
 
 export default function TSTypeAssertion(generator: Generator, node: AnyNode) {
   node = tsTypeAssertion.assert(node);
-  generator.token('<');
-  generator.print(node.typeAnnotation, node);
-  generator.token('>');
-  generator.space();
+  if (generator.options.typeAnnotations) {
+    generator.token('<');
+    generator.print(node.typeAnnotation, node);
+    generator.token('>');
+    generator.space();
+  }
   generator.print(node.expression, node);
 }


### PR DESCRIPTION
We were bailing out when `typeAnnotations: false` when we should special case them as they're actual value wrappers.