### PR TITLE
Instructions for building on Windows 10.

### DIFF
--- a/website/docs/introduction/installation.md
+++ b/website/docs/introduction/installation.md
@@ -24,6 +24,12 @@ Then, navigate into it and build `rome`:
 cd rome; ./scripts/build-release dist
 ```
 
+On Windows 10 build `rome` using the following command using PowerShell 7:
+
+```powershell
+cd rome && node scripts/build-release dist
+```
+
 Now, install `rome` globally:
 
 ```


### PR DESCRIPTION
On Windows the ```cd rome; ./scripts/build-release dist``` does not work. The following works on Windows; ```cd rome && node scripts/build-release dist```. This requires PowerShell 7 just for the && to work.