### PR TITLE
Dangling backslash

### DIFF
--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -863,6 +863,7 @@ export const descriptions = createMessages({
     INVALID_INT_TOKEN: 'Invalid or unexpected int token',
     UNICODE_ESCAPE_IN_REGEX_FLAGS: 'Regular expression flags can\'t contain unicode escapes',
     UNTERMINATED_REGEX: 'Unterminated regular expression',
+    DANGLING_BACKSLASH_IN_REGEX: 'Dangling backslash in a regular expression',
     EXPECTED_RELATIONAL_OPERATOR: 'Expected relational operator',
     UNEXPECTED_SPACE: 'Unexpected space',
     EXPECTED_SEMI_OR_LINE_TERMINATOR: 'Expected a semicolon or a line terminator',

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -977,6 +977,16 @@ export function readRegexp(parser: JSParser): void {
 
     const ch = parser.input.charAt(getIndex(parser));
     if (lineBreak.test(ch)) {
+      if(parser.input.charAt(getIndex(parser) - 2) === String.fromCharCode(charCodes.backslash) 
+      || parser.input.charAt(getIndex(parser) - 3) === String.fromCharCode(charCodes.backslash)) {
+        const line = parser.input.slice(0, getIndex(parser));
+        const backslashIndex = line.lastIndexOf(String.fromCharCode(charCodes.backslash));
+        parser.addDiagnostic({
+          end: parser.getPositionFromIndex(coerce0(backslashIndex)),
+          description: descriptions.JS_PARSER.DANGLING_BACKSLASH_IN_REGEX,
+        });
+        break;
+      }
       parser.addDiagnostic({
         end: parser.getPositionFromIndex(parser.state.index),
         description: descriptions.JS_PARSER.UNTERMINATED_REGEX,

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -977,10 +977,15 @@ export function readRegexp(parser: JSParser): void {
 
     const ch = parser.input.charAt(getIndex(parser));
     if (lineBreak.test(ch)) {
-      if(parser.input.charAt(getIndex(parser) - 2) === String.fromCharCode(charCodes.backslash) 
-      || parser.input.charAt(getIndex(parser) - 3) === String.fromCharCode(charCodes.backslash)) {
+      if (parser.input.charAt(getIndex(parser) - 2) === String.fromCharCode(
+        charCodes.backslash,
+      ) || parser.input.charAt(getIndex(parser) - 3) === String.fromCharCode(
+        charCodes.backslash,
+      )) {
         const line = parser.input.slice(0, getIndex(parser));
-        const backslashIndex = line.lastIndexOf(String.fromCharCode(charCodes.backslash));
+        const backslashIndex = line.lastIndexOf(String.fromCharCode(
+          charCodes.backslash,
+        ));
         parser.addDiagnostic({
           end: parser.getPositionFromIndex(coerce0(backslashIndex)),
           description: descriptions.JS_PARSER.DANGLING_BACKSLASH_IN_REGEX,


### PR DESCRIPTION
In https://github.com/facebookexperimental/rome/pull/192, we reverted the dangling backlash lint rule https://github.com/facebookexperimental/rome/pull/181 since it was being checked during the lint phases rather than during parsing.

This PR performs the check in the parser instead.
![image](https://user-images.githubusercontent.com/5262527/77836132-d9ce5f80-7129-11ea-8892-1d9d8b741fc8.png)


PS: I wasn't sure how to add tests. If I should, can you point me where/how to add them? I saw `@romejs/js-parser/test-fixtures`, but I wasn't sure if that's where to add them

Thanks