### PR TITLE
add repository & bugs field for vscode extension

### DIFF
--- a/packages/@romejs-integration/vscode/package.json
+++ b/packages/@romejs-integration/vscode/package.json
@@ -19,5 +19,12 @@
   },
   "dependencies": {
     "vscode-languageclient": "^5.2.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebookexperimental/rome.git"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/rome/issues"
   }
 }


### PR DESCRIPTION
`repository` and `bugs` are optional fields which let users easily navigate to the repository and submit bugs from the vscode marketplace.

<img width="230" alt="Screenshot 2020-03-30 at 07 47 24" src="https://user-images.githubusercontent.com/19197564/77883668-7ba19980-725b-11ea-83e0-76e88520f5c4.png">

Slightly unrelated: Also I registered the `rome` and `romejs` namespace for vscode extensions and I recently updated the extension to be whats on master with your recent rewrite. I don't mind donating the namespace to you or if thats not possible I'll just update it whenever there is a version bump to the extension. The extension can be found [here](https://marketplace.visualstudio.com/items?itemName=rome.rome).