### PR TITLE
Add new files to the VCS's modified files

### DIFF
--- a/packages/@romejs/vcs/index.ts
+++ b/packages/@romejs/vcs/index.ts
@@ -76,7 +76,7 @@ class GitVCSClient extends VCSClient {
     const files: Array<string> = [];
 
     for (const line of lines) {
-      const match = line.match(/^[M]\s+(.*?)$/);
+      const match = line.match(/^[AM]\s+(.*?)$/);
       if (match != null) {
         files.push(match[1]);
       }


### PR DESCRIPTION
Before this change, any new files wouldn't be picked. The reason behind this change is to be able to run `rome lint --fix --changed` on the entire changeset.