### PR TITLE
Fix Docusaurus theme image config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,7 +16,7 @@ module.exports = {
   organizationName: 'facebookexperimental',
   projectName: 'rome',
   themeConfig: {
-    image: 'https://romejs.dev/img/rome-logo.png',
+    image: 'img/rome-logo.png',
     navbar: {
       title: 'Rome',
       logo: {


### PR DESCRIPTION
Fix the following meta header:
```
<meta data-react-helmet="true" property="og:image" content="https://romejs.devhttps://romejs.dev/img/rome-logo.png">
<meta data-react-helmet="true" property="twitter:image" content="https://romejs.devhttps://romejs.dev/img/rome-logo.png">
```