### PR TITLE
Fixes for Windows Contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "romeLSPBin": "./scripts/vendor-rome",
   "scripts": {
-    "dev-rome": "./scripts/dev-rome",
-    "test": "./scripts/dev-rome test",
-    "lint": "./scripts/dev-rome lint",
-    "fix": "./scripts/dev-rome --fix"
+    "dev-rome": "node ./scripts/dev-rome",
+    "test": "node ./scripts/dev-rome test",
+    "lint": "node ./scripts/dev-rome lint",
+    "fix": "node ./scripts/dev-rome --fix"
   },
   "rome": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev-rome": "node ./scripts/dev-rome",
     "test": "node ./scripts/dev-rome test",
     "lint": "node ./scripts/dev-rome lint",
-    "fix": "node ./scripts/dev-rome --fix"
+    "lint-fix": "node ./scripts/dev-rome lint --fix"
   },
   "rome": {
     "root": true,

--- a/packages/@romejs/cli-flags/Parser.ts
+++ b/packages/@romejs/cli-flags/Parser.ts
@@ -444,7 +444,7 @@ export default class Parser<T> {
     // Output options
     for (const {arg, description} of optionOutput) {
       lines.push(
-        markup`<brightBlack><pad count="${argColumnLength}" dir="right">${arg}</brightBlack>  ${description}`,
+        markup`<brightBlack><pad count="${argColumnLength}" dir="right">${arg}</pad></brightBlack>  ${description}`,
       );
     }
 

--- a/packages/@romejs/cli-reporter/Progress.ts
+++ b/packages/@romejs/cli-reporter/Progress.ts
@@ -257,6 +257,10 @@ export default class Progress extends ProgressBase {
     });
   }
 
+  backslashCharToSlash(str: string) {
+    return str === '\\' ? '/' : str;
+  }
+
   buildProgressBouncer(stream: ReporterStream, bar: SplitBar): string {
     let start = this.getBouncerPosition(stream);
     let fullBar = '';
@@ -270,7 +274,7 @@ export default class Progress extends ProgressBase {
           fullBar += markupTag('white', markupTag('bgYellow', char));
         }
       } else {
-        fullBar += char;
+        fullBar += this.backslashCharToSlash(char);
       }
     }
     return fullBar;
@@ -289,7 +293,7 @@ export default class Progress extends ProgressBase {
           fullBar += markupTag('white', markupTag('bgGreen', char));
         }
       } else {
-        fullBar += char;
+        fullBar += this.backslashCharToSlash(char);
       }
     }
     return fullBar;

--- a/packages/@romejs/string-markup/escape.ts
+++ b/packages/@romejs/string-markup/escape.ts
@@ -70,6 +70,16 @@ export function escapeMarkup(input: string): string {
   return escaped;
 }
 
+/**
+ * If the string ends with a backslash, it replaces it with 2 backslashes to escape it
+ */
+export function escapeEndingBackslash(text: string): string {
+  if (text.endsWith("\\") && !text.endsWith("\\\\")) {
+    return text.replace(/.$/, "\\\\");
+  }
+  return text;
+}
+
 export function markupTag(
   tagName: MarkupTagName,
   text: string,
@@ -84,7 +94,7 @@ export function markupTag(
     }
   }
 
-  ret += `>${text}</${tagName}>`;
+  ret += `>${escapeEndingBackslash(text)}</${tagName}>`;
 
   return ret;
 }

--- a/packages/@romejs/string-markup/escape.ts
+++ b/packages/@romejs/string-markup/escape.ts
@@ -75,7 +75,7 @@ export function escapeMarkup(input: string): string {
  */
 export function escapeEndingBackslash(text: string): string {
   if (text.endsWith('\\') && !text.endsWith('\\\\')) {
-    return text.replace(/.$/, '\\\\');
+    return text.replace(/.$/, '/');
   }
   return text;
 }

--- a/packages/@romejs/string-markup/escape.ts
+++ b/packages/@romejs/string-markup/escape.ts
@@ -74,8 +74,8 @@ export function escapeMarkup(input: string): string {
  * If the string ends with a backslash, it replaces it with 2 backslashes to escape it
  */
 export function escapeEndingBackslash(text: string): string {
-  if (text.endsWith("\\") && !text.endsWith("\\\\")) {
-    return text.replace(/.$/, "\\\\");
+  if (text.endsWith('\\') && !text.endsWith('\\\\')) {
+    return text.replace(/.$/, '\\\\');
   }
   return text;
 }


### PR DESCRIPTION
From the get-go several issues appear when checking out the romejs code base on Windows. Immediately it is clear that shebangs are used inside the scripts and therefore cannot be run through the 'native yarn way' using yarn run.

-> I have not removed the shebangs in the scripts themselves, but in the package.json I have prefixed the commands with node, this should not have any negative effects, but should allow Windows users to simply use npm run rome-dev etc., even in Powershell.

When using npm test, I received a curious error:

✖ Fatal error occurred: DiagnosticsError: Expected to close bgYellow but found white

It turns out that because I am on Windows, the backslashes used by Windows when it comes to the file system cause an issue:

C:\Users\Nasse\rome

This is specifically a problem inside the buildProgressBouncer method in Progress.ts, which calls the markupTag function with single characters. If this character is a backslash, the html closing tags are escaped, which causes the problem.

-> I am not sure if this is optimal, but I have added a function, which escapes ending backslashes, this fixes the issue and makes the lint and test comands work on my Windows machine.