### PR TITLE
Check for children.length when printing a selfClosing JSXElement

### DIFF
--- a/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
@@ -32,7 +32,7 @@ export default function JSXElement(builder: Builder, node: AnyNode): Tokens {
     ];
   }
 
-  if (node.selfClosing === true) {
+  if (node.selfClosing === true && node.children.length === 0) {
     return [...tokens, space, operator('/>')];
   } else {
     return [


### PR DESCRIPTION
Right now it's possible to manipulate the children of a `JSXElement` and if it's `selfClosing` then it's children will not be output. This adds a check to the code generator to only output it that way when it has no children.

I considered getting rid of the `selfClosing` property all together, and just leaving in the `children.length === 0` case, but if that's used with the formatter then as someone is developing they'll have go back and constantly readd the end tag. This way we preserve the original intent.