### PR TITLE
Avoid array copies for the formatter

### DIFF
--- a/packages/@romejs/js-formatter/Printer.ts
+++ b/packages/@romejs/js-formatter/Printer.ts
@@ -507,26 +507,25 @@ export default class Printer {
   findUnbrokenGroupForLinkedGroups(
     tokens: Tokens,
   ): undefined | LinkedGroupsToken | GroupToken {
-    for (const token of tokens) {
-      let group: undefined | LinkedGroupsToken | GroupToken;
+    const stacks = [tokens];
 
-      switch (token.type) {
-        case 'LinkedGroups':
-        case 'Group':
-          if (!this.isGroupBroken(token)) {
-            group = token;
+    for (const stack of stacks) {
+      for (let token of stack) {
+        switch (token.type) {
+          case 'LinkedGroups':
+          case 'Group':
+            if (!this.isGroupBroken(token)) {
+              return token;
+            }
+            break;
+
+          case 'ConcatToken':
+          case 'Indent':
+          case 'PositionMarker': {
+            stacks.push(token.tokens);
+            break;
           }
-          break;
-
-        case 'ConcatToken':
-        case 'Indent':
-        case 'PositionMarker':
-          group = this.findUnbrokenGroupForLinkedGroups(token.tokens);
-          break;
-      }
-
-      if (group !== undefined) {
-        return group;
+        }
       }
     }
 

--- a/packages/@romejs/js-formatter/Printer.ts
+++ b/packages/@romejs/js-formatter/Printer.ts
@@ -19,6 +19,7 @@ import {
   OperatorToken,
   VerbatimToken,
   PositionMarkerToken,
+  ConcatToken,
 } from './tokens';
 import {BuilderOptions} from './Builder';
 import {
@@ -517,6 +518,7 @@ export default class Printer {
           }
           break;
 
+        case 'ConcatToken':
         case 'Indent':
         case 'PositionMarker':
           group = this.findUnbrokenGroupForLinkedGroups(token.tokens);
@@ -584,6 +586,10 @@ export default class Printer {
     state.sourceLocation = origSourceLocation;
   }
 
+  printConcatToken(token: ConcatToken) {
+    this.print(token.tokens);
+  }
+
   print(tokens: undefined | Tokens, i: number = 0) {
     if (tokens === undefined) {
       return;
@@ -645,6 +651,10 @@ export default class Printer {
 
         case 'PositionMarker':
           this.printPositionMarkerToken(token);
+          break;
+
+        case 'ConcatToken':
+          this.printConcatToken(token);
           break;
       }
 

--- a/packages/@romejs/js-formatter/builders/auxiliary/CatchClause.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/CatchClause.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {CatchClause, catchClause, AnyNode} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {catchClause, AnyNode} from '@romejs/js-ast';
 import {word, space, operator} from '@romejs/js-formatter/tokens';
 
 export default function CatchClause(builder: Builder, node: AnyNode): Tokens {
@@ -17,9 +17,9 @@ export default function CatchClause(builder: Builder, node: AnyNode): Tokens {
     word('catch'),
     space,
     operator('('),
-    ...builder.tokenize(node.param, node),
+    concat(builder.tokenize(node.param, node)),
     operator(')'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/auxiliary/ComputedMemberProperty.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/ComputedMemberProperty.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {
-  ComputedMemberProperty,
-  computedMemberProperty,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {computedMemberProperty, AnyNode} from '@romejs/js-ast';
 import {operator} from '@romejs/js-formatter/tokens';
 
 export default function ComputedMemberProperty(
@@ -20,5 +16,9 @@ export default function ComputedMemberProperty(
 ): Tokens {
   node = computedMemberProperty.assert(node);
 
-  return [operator('['), ...builder.tokenize(node.value, node), operator(']')];
+  return [
+    operator('['),
+    concat(builder.tokenize(node.value, node)),
+    operator(']'),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/auxiliary/FunctionHead.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/FunctionHead.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {FunctionHead, functionHead, AnyNode} from '@romejs/js-ast';
+import {functionHead, AnyNode} from '@romejs/js-ast';
 import {Builder} from '@romejs/js-formatter';
 import {printBindingPatternParams} from '../utils';
 import {
@@ -13,6 +13,7 @@ import {
   operator,
   Tokens,
   linkedGroups,
+  concat,
 } from '@romejs/js-formatter/tokens';
 
 export default function FunctionHead(builder: Builder, node: AnyNode): Tokens {
@@ -20,15 +21,15 @@ export default function FunctionHead(builder: Builder, node: AnyNode): Tokens {
 
   const {typeAnnotations} = builder.options;
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     operator('('),
-    ...printBindingPatternParams(builder, node, node.params, node.rest),
+    concat(printBindingPatternParams(builder, node, node.params, node.rest)),
     operator(')'),
   ];
 
   if (typeAnnotations) {
     if (node.returnType) {
-      tokens = tokens.concat(builder.tokenizeTypeColon(node.returnType, node));
+      tokens.push(concat(builder.tokenizeTypeColon(node.returnType, node)));
     }
 
     if (node.predicate) {
@@ -36,9 +37,12 @@ export default function FunctionHead(builder: Builder, node: AnyNode): Tokens {
         tokens.push(operator(':'));
       }
       tokens.push(space);
-      tokens = tokens.concat(builder.tokenize(node.predicate, node));
+      tokens.push(concat(builder.tokenize(node.predicate, node)));
     }
   }
 
-  return [...builder.tokenize(node.typeParameters, node), linkedGroups(tokens)];
+  return [
+    concat(builder.tokenize(node.typeParameters, node)),
+    linkedGroups(tokens),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/auxiliary/Identifier.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/Identifier.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {AnyNode, Identifier, identifier} from '@romejs/js-ast';
+import {AnyNode, identifier} from '@romejs/js-ast';
 import {word} from '@romejs/js-formatter/tokens';
 
 export default function Identifier(builder: Builder, node: AnyNode): Tokens {

--- a/packages/@romejs/js-formatter/builders/auxiliary/SpreadElement.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/SpreadElement.ts
@@ -6,11 +6,11 @@
  */
 
 import Builder from '../../Builder';
-import {SpreadElement, spreadElement, AnyNode} from '@romejs/js-ast';
-import {operator, Tokens} from '@romejs/js-formatter/tokens';
+import {spreadElement, AnyNode} from '@romejs/js-ast';
+import {operator, Tokens, concat} from '@romejs/js-formatter/tokens';
 
 export default function SpreadElement(builder: Builder, node: AnyNode): Tokens {
   node = spreadElement.assert(node);
 
-  return [operator('...'), ...builder.tokenize(node.argument, node)];
+  return [operator('...'), concat(builder.tokenize(node.argument, node))];
 }

--- a/packages/@romejs/js-formatter/builders/auxiliary/StaticMemberProperty.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/StaticMemberProperty.ts
@@ -6,15 +6,11 @@
  */
 
 import Builder from '../../Builder';
-import {
-  StaticMemberProperty,
-  staticMemberProperty,
-  AnyNode,
-} from '@romejs/js-ast';
-import {operator} from '@romejs/js-formatter/tokens';
+import {staticMemberProperty, AnyNode} from '@romejs/js-ast';
+import {operator, concat} from '@romejs/js-formatter/tokens';
 
 export default function StaticMemberProperty(builder: Builder, node: AnyNode) {
   node = staticMemberProperty.assert(node);
 
-  return [operator('.'), ...builder.tokenize(node.value, node)];
+  return [operator('.'), concat(builder.tokenize(node.value, node))];
 }

--- a/packages/@romejs/js-formatter/builders/auxiliary/SwitchCase.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/SwitchCase.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {SwitchCase, switchCase, AnyNode} from '@romejs/js-ast';
+import {switchCase, AnyNode} from '@romejs/js-ast';
 import {
   word,
   space,
@@ -14,6 +14,7 @@ import {
   operator,
   indent,
   Tokens,
+  concat,
 } from '@romejs/js-formatter/tokens';
 
 export default function SwitchCase(builder: Builder, node: AnyNode): Tokens {
@@ -25,7 +26,7 @@ export default function SwitchCase(builder: Builder, node: AnyNode): Tokens {
     tokens = [
       word('case'),
       space,
-      ...builder.tokenize(node.test, node),
+      concat(builder.tokenize(node.test, node)),
       operator(':'),
     ];
   } else {
@@ -35,7 +36,7 @@ export default function SwitchCase(builder: Builder, node: AnyNode): Tokens {
   const {consequent} = node;
   if (consequent.length === 1 && consequent[0].type === 'BlockStatement') {
     tokens.push(space);
-    tokens = tokens.concat(builder.tokenize(consequent[0], node));
+    tokens.push(concat(builder.tokenize(consequent[0], node)));
   } else if (consequent.length > 0) {
     tokens.push(newline);
     tokens.push(indent(builder.tokenizeStatementList(consequent, node)));

--- a/packages/@romejs/js-formatter/builders/auxiliary/TemplateElement.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/TemplateElement.ts
@@ -6,12 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {
-  AnyNode,
-  TemplateElement,
-  templateLiteral,
-  templateElement,
-} from '@romejs/js-ast';
+import {AnyNode, templateLiteral, templateElement} from '@romejs/js-ast';
 import {operator} from '@romejs/js-formatter/tokens';
 
 export default function TemplateElement(

--- a/packages/@romejs/js-formatter/builders/auxiliary/VariableDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/VariableDeclaration.ts
@@ -6,11 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {
-  AnyNode,
-  VariableDeclaration,
-  variableDeclaration,
-} from '@romejs/js-ast';
+import {AnyNode, variableDeclaration} from '@romejs/js-ast';
 import {word, space} from '@romejs/js-formatter/tokens';
 
 export default function VariableDeclaration(builder: Builder, node: AnyNode) {

--- a/packages/@romejs/js-formatter/builders/auxiliary/VariableDeclarator.ts
+++ b/packages/@romejs/js-formatter/builders/auxiliary/VariableDeclarator.ts
@@ -6,19 +6,19 @@
  */
 
 import Builder from '../../Builder';
-import {VariableDeclarator, variableDeclarator, AnyNode} from '@romejs/js-ast';
-import {operator, space} from '@romejs/js-formatter/tokens';
+import {variableDeclarator, AnyNode} from '@romejs/js-ast';
+import {operator, space, concat} from '@romejs/js-formatter/tokens';
 
 export default function VariableDeclarator(builder: Builder, node: AnyNode) {
   node = variableDeclarator.assert(node);
 
   if (node.init) {
     return [
-      ...builder.tokenize(node.id, node),
+      concat(builder.tokenize(node.id, node)),
       space,
       operator('='),
       space,
-      ...builder.tokenize(node.init, node),
+      concat(builder.tokenize(node.init, node)),
     ];
   } else {
     return builder.tokenize(node.id, node);

--- a/packages/@romejs/js-formatter/builders/classes/ClassDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassDeclaration.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator, word} from '../../tokens';
-import {ClassDeclaration, classDeclaration, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, operator, word, concat} from '../../tokens';
+import {classDeclaration, AnyNode} from '@romejs/js-ast';
 
 export default function ClassDeclaration(
   builder: Builder,
@@ -15,20 +15,20 @@ export default function ClassDeclaration(
 ): Tokens {
   node = node.type === 'ClassExpression' ? node : classDeclaration.assert(node);
 
-  let tokens: Tokens = [word('class')];
+  const tokens: Tokens = [word('class')];
 
   if (node.id) {
-    tokens = [...tokens, space, ...builder.tokenize(node.id, node)];
+    tokens.push(space, concat(builder.tokenize(node.id, node)));
   }
 
   return [
-    ...tokens,
-    ...builder.tokenize(node.meta, node),
+    concat(tokens),
+    concat(builder.tokenize(node.meta, node)),
     space,
     operator('{'),
-    ...builder.tokenizeInnerComments(node),
-    ...builder.tokenizeInnerComments(node.meta),
-    ...builder.tokenizeStatementList(node.meta.body, node.meta, true),
+    concat(builder.tokenizeInnerComments(node)),
+    concat(builder.tokenizeInnerComments(node.meta)),
+    concat(builder.tokenizeStatementList(node.meta.body, node.meta, true)),
     operator('}'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/classes/ClassHead.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassHead.ts
@@ -6,34 +6,27 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space} from '../../tokens';
-import {ClassHead, classHead, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, space, concat} from '../../tokens';
+import {classHead, AnyNode} from '@romejs/js-ast';
 
 export default function ClassHead(builder: Builder, node: AnyNode): Tokens {
   node = classHead.assert(node);
 
-  let tokens: Tokens = builder.tokenize(node.typeParameters, node);
+  const tokens: Tokens = builder.tokenize(node.typeParameters, node);
 
   if (node.superClass) {
-    tokens = [
-      ...tokens,
-      space,
-      word('extends'),
-      space,
-      ...builder.tokenize(node.superClass, node),
-      ...builder.tokenize(node.superTypeParameters, node),
-    ];
+    tokens.push(space, word('extends'), space, concat(builder.tokenize(
+      node.superClass,
+      node,
+    )), concat(builder.tokenize(node.superTypeParameters, node)));
   }
 
   if (node.implements !== undefined && node.implements.length > 0 &&
       builder.options.typeAnnotations) {
-    tokens = [
-      ...tokens,
-      space,
-      word('implements'),
-      space,
-      builder.tokenizeCommaList(node.implements, node),
-    ];
+    tokens.push(space, word('implements'), space, builder.tokenizeCommaList(
+      node.implements,
+      node,
+    ));
   }
 
   return tokens;

--- a/packages/@romejs/js-formatter/builders/classes/ClassMethod.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassMethod.ts
@@ -6,18 +6,18 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, word} from '../../tokens';
-import {ClassMethod, classMethod, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, word, concat} from '../../tokens';
+import {classMethod, AnyNode} from '@romejs/js-ast';
 import {printMethod} from '../utils';
 
 export default function ClassMethod(builder: Builder, node: AnyNode): Tokens {
   node = classMethod.assert(node);
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = printMethod(builder, node);
 
   if (node.meta.static === true) {
-    tokens = [word('static'), space];
+    return [word('static'), space, concat(tokens)];
+  } else {
+    return tokens;
   }
-
-  return [...tokens, ...printMethod(builder, node)];
 }

--- a/packages/@romejs/js-formatter/builders/classes/ClassPrivateProperty.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassPrivateProperty.ts
@@ -7,22 +7,22 @@
 
 import Builder from '../../Builder';
 import {AnyNode, classPrivateProperty} from '@romejs/js-ast';
-import {Tokens, operator, space} from '@romejs/js-formatter/tokens';
+import {Tokens, operator, space, concat} from '@romejs/js-formatter/tokens';
 
 export default function ClassPrivateProperty(builder: Builder, node: AnyNode) {
   node = classPrivateProperty.assert(node);
 
-  let tokens: Tokens = [
-    ...builder.tokenize(node.meta, node),
-    ...builder.tokenize(node.key, node),
-    ...builder.tokenizeTypeColon(node.typeAnnotation, node),
+  const tokens: Tokens = [
+    concat(builder.tokenize(node.meta, node)),
+    concat(builder.tokenize(node.key, node)),
+    concat(builder.tokenizeTypeColon(node.typeAnnotation, node)),
   ];
 
   if (node.value) {
     tokens.push(space);
     tokens.push(operator('='));
     tokens.push(space);
-    tokens = tokens.concat(builder.tokenize(node.value, node));
+    tokens.push(concat(builder.tokenize(node.value, node)));
   }
 
   tokens.push(operator(';'));

--- a/packages/@romejs/js-formatter/builders/classes/ClassProperty.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassProperty.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator} from '../../tokens';
-import {ClassProperty, classProperty, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, operator, concat} from '../../tokens';
+import {classProperty, AnyNode} from '@romejs/js-ast';
 
 export default function ClassProperty(builder: Builder, node: AnyNode): Tokens {
   node = classProperty.assert(node);
@@ -18,21 +18,19 @@ export default function ClassProperty(builder: Builder, node: AnyNode): Tokens {
   }
 
   const tokens: Tokens = [
-    ...builder.tokenize(node.meta, node),
-    ...builder.tokenize(node.key, node),
-    ...builder.tokenizeTypeColon(node.typeAnnotation, node),
+    concat(builder.tokenize(node.meta, node)),
+    concat(builder.tokenize(node.key, node)),
+    concat(builder.tokenizeTypeColon(node.typeAnnotation, node)),
   ];
 
   if (node.value) {
-    return [
-      ...tokens,
-      space,
-      operator('='),
-      space,
-      ...builder.tokenize(node.value, node),
-      operator(';'),
-    ];
-  } else {
-    return [...tokens, operator(';')];
+    tokens.push(space);
+    tokens.push(operator('='));
+    tokens.push(space);
+    tokens.push(concat(builder.tokenize(node.value, node)));
   }
+
+  tokens.push(operator(';'));
+
+  return tokens;
 }

--- a/packages/@romejs/js-formatter/builders/classes/ClassPropertyMeta.ts
+++ b/packages/@romejs/js-formatter/builders/classes/ClassPropertyMeta.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens, word} from '../../tokens';
-import {ClassPropertyMeta, classPropertyMeta, AnyNode} from '@romejs/js-ast';
+import {classPropertyMeta, AnyNode} from '@romejs/js-ast';
 
 export default function ClassPropertyMeta(
   builder: Builder,
@@ -15,7 +15,7 @@ export default function ClassPropertyMeta(
 ): Tokens {
   node = classPropertyMeta.assert(node);
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = [];
 
   if (!builder.options.typeAnnotations) {
     if (node.accessibility) {

--- a/packages/@romejs/js-formatter/builders/classes/PrivateName.ts
+++ b/packages/@romejs/js-formatter/builders/classes/PrivateName.ts
@@ -7,10 +7,10 @@
 
 import Builder from '../../Builder';
 import {AnyNode, privateName} from '@romejs/js-ast';
-import {operator} from '@romejs/js-formatter/tokens';
+import {operator, concat} from '@romejs/js-formatter/tokens';
 
 export default function PrivateName(builder: Builder, node: AnyNode) {
   node = privateName.assert(node);
 
-  return [operator('#'), ...builder.tokenize(node.id, node)];
+  return [operator('#'), concat(builder.tokenize(node.id, node))];
 }

--- a/packages/@romejs/js-formatter/builders/core/Directive.ts
+++ b/packages/@romejs/js-formatter/builders/core/Directive.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {operator} from '../../tokens';
+import {operator, concat} from '../../tokens';
 import {AnyNode} from '@romejs/js-ast';
 import StringLiteral from '../literals/StringLiteral';
 
@@ -15,5 +15,5 @@ export default function Directive(
   node: AnyNode,
   parent: AnyNode,
 ) {
-  return [...StringLiteral(builder, node, parent), operator(';')];
+  return [concat(StringLiteral(builder, node, parent)), operator(';')];
 }

--- a/packages/@romejs/js-formatter/builders/core/Program.ts
+++ b/packages/@romejs/js-formatter/builders/core/Program.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Program, program, AnyNode} from '@romejs/js-ast';
-import {Tokens, newline} from '@romejs/js-formatter/tokens';
+import {program, AnyNode} from '@romejs/js-ast';
+import {Tokens, newline, concat} from '@romejs/js-formatter/tokens';
 
 export default function Program(builder: Builder, node: AnyNode): Tokens {
   node = program.assert(node);
@@ -19,8 +19,8 @@ export default function Program(builder: Builder, node: AnyNode): Tokens {
   }
 
   return [
-    ...tokens,
-    ...builder.tokenizeInnerComments(node),
-    ...builder.tokenizeStatementList(node.body, node),
+    concat(tokens),
+    concat(builder.tokenizeInnerComments(node)),
+    concat(builder.tokenizeStatementList(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/ArrayExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/ArrayExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator} from '../../tokens';
-import {ArrayExpression, arrayExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, operator, concat} from '../../tokens';
+import {arrayExpression, AnyNode} from '@romejs/js-ast';
 
 export default function ArrayExpression(
   builder: Builder,
@@ -18,9 +18,9 @@ export default function ArrayExpression(
 
   const elems = node.elements;
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     operator('['),
-    ...builder.tokenizeInnerComments(node),
+    concat(builder.tokenizeInnerComments(node)),
     builder.tokenizeCommaList(elems, node, {
       trailing: true,
       breakOnNewline: true,
@@ -34,7 +34,7 @@ export default function ArrayExpression(
       tokens.push(space);
     }
 
-    tokens = [...tokens, operator('...'), ...builder.tokenize(node.rest, node)];
+    tokens.push(operator('...'), concat(builder.tokenize(node.rest, node)));
   }
 
   tokens.push(operator(']'));

--- a/packages/@romejs/js-formatter/builders/expressions/ArrowFunctionExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/ArrowFunctionExpression.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, word, space} from '../../tokens';
-import {
-  ArrowFunctionExpression,
-  arrowFunctionExpression,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, word, space, concat} from '../../tokens';
+import {arrowFunctionExpression, AnyNode} from '@romejs/js-ast';
 
 export default function ArrowFunctionExpression(builder: Builder, node: AnyNode) {
   node = arrowFunctionExpression.assert(node);
@@ -24,11 +20,11 @@ export default function ArrowFunctionExpression(builder: Builder, node: AnyNode)
   }
 
   return [
-    ...tokens,
-    ...builder.tokenize(node.head, node),
+    concat(tokens),
+    concat(builder.tokenize(node.head, node)),
     space,
     operator('=>'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/AssignmentExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/AssignmentExpression.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, word, breakGroup, space} from '../../tokens';
+import {Tokens, operator, word, breakGroup, space, concat} from '../../tokens';
 import {
   AnyNode,
   AssignmentExpression,
@@ -49,7 +49,7 @@ export default function AssignmentExpression(
 
   const right = builder.tokenize(node.right, node);
 
-  tokens.push(breakGroup([[...left, space, sep], right]));
+  tokens.push(breakGroup([[concat(left), space, sep], right]));
 
   if (needsExtraParens) {
     tokens.push(operator(')'));

--- a/packages/@romejs/js-formatter/builders/expressions/CallExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/CallExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {CallExpression, callExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {callExpression, AnyNode} from '@romejs/js-ast';
 
 export default function CallExpression(builder: Builder, node: AnyNode): Tokens {
     node =
@@ -16,8 +16,8 @@ export default function CallExpression(builder: Builder, node: AnyNode): Tokens 
       : callExpression.assert(node);
 
   const tokens: Tokens = [
-    ...builder.tokenize(node.callee, node),
-    ...builder.tokenize(node.typeArguments, node),
+    concat(builder.tokenize(node.callee, node)),
+    concat(builder.tokenize(node.typeArguments, node)),
   ];
 
   if (node.type === 'OptionalCallExpression') {
@@ -25,7 +25,7 @@ export default function CallExpression(builder: Builder, node: AnyNode): Tokens 
   }
 
   return [
-    ...tokens,
+    concat(tokens),
     operator('('),
     builder.tokenizeCommaList(node.arguments, node, {
       trailing: true,

--- a/packages/@romejs/js-formatter/builders/expressions/ConditionalExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/ConditionalExpression.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space, group, newline} from '../../tokens';
-import {
-  ConditionalExpression,
-  conditionalExpression,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, space, group, newline, concat} from '../../tokens';
+import {conditionalExpression, AnyNode} from '@romejs/js-ast';
 
 export default function ConditionalExpression(
   builder: Builder,
@@ -20,11 +16,11 @@ export default function ConditionalExpression(
   node = conditionalExpression.assert(node);
 
   return [
-    ...builder.tokenize(node.test, node),
+    concat(builder.tokenize(node.test, node)),
     space,
     group([
-      [operator('?'), space, ...builder.tokenize(node.consequent, node)],
-      [operator(':'), space, ...builder.tokenize(node.alternate, node)],
+      [operator('?'), space, concat(builder.tokenize(node.consequent, node))],
+      [operator(':'), space, concat(builder.tokenize(node.alternate, node))],
     ], {
       priority: true,
       broken: {

--- a/packages/@romejs/js-formatter/builders/expressions/DoExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/DoExpression.ts
@@ -6,11 +6,11 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space} from '../../tokens';
-import {DoExpression, doExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, space, concat} from '../../tokens';
+import {doExpression, AnyNode} from '@romejs/js-ast';
 
 export default function DoExpression(builder: Builder, node: AnyNode): Tokens {
   node = doExpression.assert(node);
 
-  return [word('do'), space, ...builder.tokenize(node.body, node)];
+  return [word('do'), space, concat(builder.tokenize(node.body, node))];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/FunctionExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/FunctionExpression.ts
@@ -6,8 +6,15 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator, word, linkedGroups} from '../../tokens';
-import {FunctionExpression, functionExpression, AnyNode} from '@romejs/js-ast';
+import {
+  Tokens,
+  space,
+  operator,
+  word,
+  linkedGroups,
+  concat,
+} from '../../tokens';
+import {functionExpression, AnyNode} from '@romejs/js-ast';
 
 export default function FunctionExpression(
   builder: Builder,
@@ -17,7 +24,7 @@ export default function FunctionExpression(
     ? node
     : functionExpression.assert(node);
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = [];
 
   if (node.head.async === true) {
     tokens.push(word('async'));
@@ -31,12 +38,12 @@ export default function FunctionExpression(
   }
 
   if (node.id) {
-    tokens = [...tokens, space, ...builder.tokenize(node.id, node)];
+    tokens.push(space, concat(builder.tokenize(node.id, node)));
   }
 
   return [
-    ...tokens,
-    linkedGroups([...builder.tokenize(node.head, node), space]),
-    ...builder.tokenize(node.body, node),
+    concat(tokens),
+    linkedGroups([concat(builder.tokenize(node.head, node)), space]),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/LogicalExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/LogicalExpression.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {LogicalExpression, logicalExpression, AnyNode} from '@romejs/js-ast';
+import {logicalExpression, AnyNode} from '@romejs/js-ast';
 import AssignmentExpression from './AssignmentExpression';
 
 export default function LogicalExpression(

--- a/packages/@romejs/js-formatter/builders/expressions/MemberExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/MemberExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {MemberExpression, memberExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {memberExpression, AnyNode} from '@romejs/js-ast';
 
 export default function MemberExpression(
   builder: Builder,
@@ -16,7 +16,7 @@ export default function MemberExpression(
   node = memberExpression.assert(node);
 
   return [
-    ...builder.tokenize(node.object, node),
-    ...builder.tokenize(node.property, node),
+    concat(builder.tokenize(node.object, node)),
+    concat(builder.tokenize(node.property, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/MetaProperty.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/MetaProperty.ts
@@ -6,15 +6,15 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {MetaProperty, metaProperty, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {metaProperty, AnyNode} from '@romejs/js-ast';
 
 export default function MetaProperty(builder: Builder, node: AnyNode): Tokens {
   node = metaProperty.assert(node);
 
   return [
-    ...builder.tokenize(node.meta, node),
+    concat(builder.tokenize(node.meta, node)),
     operator('.'),
-    ...builder.tokenize(node.property, node),
+    concat(builder.tokenize(node.property, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/NewExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/NewExpression.ts
@@ -6,12 +6,12 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word} from '../../tokens';
-import {NewExpression, newExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, concat} from '../../tokens';
+import {newExpression, AnyNode} from '@romejs/js-ast';
 import CallExpression from './CallExpression';
 
 export default function NewExpression(builder: Builder, node: AnyNode): Tokens {
   node = newExpression.assert(node);
 
-  return [word('new'), ...CallExpression(builder, node)];
+  return [word('new'), concat(CallExpression(builder, node))];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/OptionalCallExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/OptionalCallExpression.ts
@@ -7,11 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {
-  OptionalCallExpression,
-  optionalCallExpression,
-  AnyNode,
-} from '@romejs/js-ast';
+import {optionalCallExpression, AnyNode} from '@romejs/js-ast';
 import CallExpression from './CallExpression';
 
 export default function OptionalCallExpression(

--- a/packages/@romejs/js-formatter/builders/expressions/ReferenceIdentifier.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/ReferenceIdentifier.ts
@@ -7,11 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {
-  ReferenceIdentifier,
-  referenceIdentifier,
-  AnyNode,
-} from '@romejs/js-ast';
+import {referenceIdentifier, AnyNode} from '@romejs/js-ast';
 import Identifier from '../auxiliary/Identifier';
 
 export default function ReferenceIdentifier(

--- a/packages/@romejs/js-formatter/builders/expressions/SequenceExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/SequenceExpression.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {SequenceExpression, sequenceExpression, AnyNode} from '@romejs/js-ast';
+import {sequenceExpression, AnyNode} from '@romejs/js-ast';
 
 export default function SequenceExpression(
   builder: Builder,

--- a/packages/@romejs/js-formatter/builders/expressions/TaggedTemplateExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/TaggedTemplateExpression.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {
-  TaggedTemplateExpression,
-  taggedTemplateExpression,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {taggedTemplateExpression, AnyNode} from '@romejs/js-ast';
 
 export default function TaggedTemplateExpression(
   builder: Builder,
@@ -20,7 +16,7 @@ export default function TaggedTemplateExpression(
   node = taggedTemplateExpression.assert(node);
 
   return [
-    ...builder.tokenize(node.tag, node),
-    ...builder.tokenize(node.quasi, node),
+    concat(builder.tokenize(node.tag, node)),
+    concat(builder.tokenize(node.quasi, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/expressions/UnaryExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/UnaryExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, word, operator} from '../../tokens';
-import {UnaryExpression, unaryExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, word, operator, concat} from '../../tokens';
+import {unaryExpression, AnyNode} from '@romejs/js-ast';
 
 export default function UnaryExpression(builder: Builder, node: AnyNode): Tokens {
   node = unaryExpression.assert(node);
@@ -18,9 +18,12 @@ export default function UnaryExpression(builder: Builder, node: AnyNode): Tokens
     return [
       word(node.operator),
       space,
-      ...builder.tokenize(node.argument, node),
+      concat(builder.tokenize(node.argument, node)),
     ];
   } else {
-    return [operator(node.operator), ...builder.tokenize(node.argument, node)];
+    return [
+      operator(node.operator),
+      concat(builder.tokenize(node.argument, node)),
+    ];
   }
 }

--- a/packages/@romejs/js-formatter/builders/expressions/UpdateExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/UpdateExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {UpdateExpression, updateExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {updateExpression, AnyNode} from '@romejs/js-ast';
 
 export default function UpdateExpression(
   builder: Builder,
@@ -16,8 +16,14 @@ export default function UpdateExpression(
   node = updateExpression.assert(node);
 
   if (node.prefix === true) {
-    return [operator(node.operator), ...builder.tokenize(node.argument, node)];
+    return [
+      operator(node.operator),
+      concat(builder.tokenize(node.argument, node)),
+    ];
   } else {
-    return [...builder.tokenize(node.argument, node), operator(node.operator)];
+    return [
+      concat(builder.tokenize(node.argument, node)),
+      operator(node.operator),
+    ];
   }
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXAttribute.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXAttribute.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {JSXAttribute, jsxAttribute, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxAttribute, AnyNode} from '@romejs/js-ast';
 
 export default function JSXAttribute(builder: Builder, node: AnyNode): Tokens {
   node = jsxAttribute.assert(node);
@@ -15,7 +15,11 @@ export default function JSXAttribute(builder: Builder, node: AnyNode): Tokens {
   const tokens: Tokens = builder.tokenize(node.name, node);
 
   if (node.value) {
-    return [...tokens, operator('='), ...builder.tokenize(node.value, node)];
+    return [
+      concat(tokens),
+      operator('='),
+      concat(builder.tokenize(node.value, node)),
+    ];
   } else {
     return tokens;
   }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, indent, flatten, operator, concat} from '../../tokens';
+import {Tokens, space, indent, operator, concat} from '../../tokens';
 import {jsxElement, AnyNode} from '@romejs/js-ast';
 
 export default function JSXElement(builder: Builder, node: AnyNode): Tokens {
@@ -32,15 +32,14 @@ export default function JSXElement(builder: Builder, node: AnyNode): Tokens {
     return [concat(tokens), space, operator('/>')];
   } else {
     return [
-      concat(tokens),
-      operator('>'),
-      indent(
-        flatten(node.children.map((child) => builder.tokenize(child, node))),
-      ),
-
-      operator('</'),
-      concat(builder.tokenize(node.name, node)),
-      operator('>'),
-    ];
+        concat(tokens),
+        operator('>'),
+        indent(node.children.map(
+          (child) => concat(builder.tokenize(child, node)),
+        )),
+        operator('</'),
+        concat(builder.tokenize(node.name, node)),
+        operator('>'),
+      ];
   }
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXElement.ts
@@ -6,44 +6,40 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, indent, flatten, operator} from '../../tokens';
-import {JSXElement, jsxElement, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, indent, flatten, operator, concat} from '../../tokens';
+import {jsxElement, AnyNode} from '@romejs/js-ast';
 
 export default function JSXElement(builder: Builder, node: AnyNode): Tokens {
   node = jsxElement.assert(node);
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     operator('<'),
-    ...builder.tokenize(node.name, node),
-    ...builder.tokenize(node.typeArguments, node),
+    concat(builder.tokenize(node.name, node)),
+    concat(builder.tokenize(node.typeArguments, node)),
   ];
 
   if (node.attributes.length > 0) {
-    tokens = [
-      ...tokens,
-      space,
-      builder.tokenizeJoin(node.attributes, node, {
-        newline: true,
-        broken: {},
-        unbroken: {
-          separator: [space],
-        },
-      }),
-    ];
+    tokens.push(space, builder.tokenizeJoin(node.attributes, node, {
+      newline: true,
+      broken: {},
+      unbroken: {
+        separator: [space],
+      },
+    }));
   }
 
   if (node.selfClosing === true && node.children.length === 0) {
-    return [...tokens, space, operator('/>')];
+    return [concat(tokens), space, operator('/>')];
   } else {
     return [
-      ...tokens,
+      concat(tokens),
       operator('>'),
       indent(
         flatten(node.children.map((child) => builder.tokenize(child, node))),
       ),
 
       operator('</'),
-      ...builder.tokenize(node.name, node),
+      concat(builder.tokenize(node.name, node)),
       operator('>'),
     ];
   }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXEmptyExpression.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXEmptyExpression.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {JSXEmptyExpression, jsxEmptyExpression, AnyNode} from '@romejs/js-ast';
+import {jsxEmptyExpression, AnyNode} from '@romejs/js-ast';
 
 export default function JSXEmptyExpression(
   builder: Builder,

--- a/packages/@romejs/js-formatter/builders/jsx/JSXExpressionContainer.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXExpressionContainer.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {
-  JSXExpressionContainer,
-  jsxExpressionContainer,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxExpressionContainer, AnyNode} from '@romejs/js-ast';
 
 export default function JSXExpressionContainer(
   builder: Builder,
@@ -21,7 +17,7 @@ export default function JSXExpressionContainer(
 
   return [
     operator('{'),
-    ...builder.tokenize(node.expression, node),
+    concat(builder.tokenize(node.expression, node)),
     operator('}'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXFragment.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXFragment.ts
@@ -6,17 +6,15 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, indent, operator, flatten} from '../../tokens';
+import {Tokens, indent, operator, concat} from '../../tokens';
 import {jsxFragment, AnyNode} from '@romejs/js-ast';
 
 export default function JSXFragment(builder: Builder, node: AnyNode): Tokens {
   node = jsxFragment.assert(node);
 
   return [
-      operator('<>'),
-      indent(
-        flatten(node.children.map((child) => builder.tokenize(child, node))),
-      ),
-      operator('</>'),
-    ];
+    operator('<>'),
+    indent(node.children.map((child) => concat(builder.tokenize(child, node)))),
+    operator('</>'),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXFragment.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXFragment.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens, indent, operator, flatten} from '../../tokens';
-import {JSXFragment, jsxFragment, AnyNode} from '@romejs/js-ast';
+import {jsxFragment, AnyNode} from '@romejs/js-ast';
 
 export default function JSXFragment(builder: Builder, node: AnyNode): Tokens {
   node = jsxFragment.assert(node);

--- a/packages/@romejs/js-formatter/builders/jsx/JSXIdentifier.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXIdentifier.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens, word} from '../../tokens';
-import {JSXIdentifier, jsxIdentifier, AnyNode} from '@romejs/js-ast';
+import {jsxIdentifier, AnyNode} from '@romejs/js-ast';
 
 export default function JSXIdentifier(builder: Builder, node: AnyNode): Tokens {
   node = jsxIdentifier.assert(node);

--- a/packages/@romejs/js-formatter/builders/jsx/JSXMemberExpression.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXMemberExpression.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {
-  JSXMemberExpression,
-  jsxMemberExpression,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxMemberExpression, AnyNode} from '@romejs/js-ast';
 
 export default function JSXMemberExpression(
   builder: Builder,
@@ -20,8 +16,8 @@ export default function JSXMemberExpression(
   node = jsxMemberExpression.assert(node);
 
   return [
-    ...builder.tokenize(node.object, node),
+    concat(builder.tokenize(node.object, node)),
     operator('.'),
-    ...builder.tokenize(node.property, node),
+    concat(builder.tokenize(node.property, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXNamespacedName.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXNamespacedName.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {JSXNamespacedName, jsxNamespacedName, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxNamespacedName, AnyNode} from '@romejs/js-ast';
 
 export default function JSXNamespacedName(
   builder: Builder,
@@ -16,8 +16,8 @@ export default function JSXNamespacedName(
   node = jsxNamespacedName.assert(node);
 
   return [
-    ...builder.tokenize(node.namespace, node),
+    concat(builder.tokenize(node.namespace, node)),
     operator(':'),
-    ...builder.tokenize(node.name, node),
+    concat(builder.tokenize(node.name, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXReferenceIdentifier.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXReferenceIdentifier.ts
@@ -7,11 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {
-  JSXReferenceIdentifier,
-  jsxReferenceIdentifier,
-  AnyNode,
-} from '@romejs/js-ast';
+import {jsxReferenceIdentifier, AnyNode} from '@romejs/js-ast';
 
 export default function JSXReferenceIdentifier(
   builder: Builder,

--- a/packages/@romejs/js-formatter/builders/jsx/JSXSpreadAttribute.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXSpreadAttribute.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {JSXSpreadAttribute, jsxSpreadAttribute, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxSpreadAttribute, AnyNode} from '@romejs/js-ast';
 
 export default function JSXSpreadAttribute(
   builder: Builder,
@@ -18,7 +18,7 @@ export default function JSXSpreadAttribute(
   return [
     operator('{'),
     operator('...'),
-    ...builder.tokenize(node.argument, node),
+    concat(builder.tokenize(node.argument, node)),
     operator('}'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXSpreadChild.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXSpreadChild.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {JSXSpreadChild, jsxSpreadChild, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {jsxSpreadChild, AnyNode} from '@romejs/js-ast';
 
 export default function JSXSpreadChild(builder: Builder, node: AnyNode): Tokens {
   node = jsxSpreadChild.assert(node);
@@ -15,7 +15,7 @@ export default function JSXSpreadChild(builder: Builder, node: AnyNode): Tokens 
   return [
     operator('{'),
     operator('...'),
-    ...builder.tokenize(node.expression, node),
+    concat(builder.tokenize(node.expression, node)),
     operator('}'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/jsx/JSXText.ts
+++ b/packages/@romejs/js-formatter/builders/jsx/JSXText.ts
@@ -7,7 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens, operator} from '../../tokens';
-import {JSXText, jsxText, AnyNode} from '@romejs/js-ast';
+import {jsxText, AnyNode} from '@romejs/js-ast';
 import {escapeXHTMLEntities} from '@romejs/js-parser';
 
 export default function JSXText(builder: Builder, node: AnyNode): Tokens {

--- a/packages/@romejs/js-formatter/builders/literals/RegExpLiteral.ts
+++ b/packages/@romejs/js-formatter/builders/literals/RegExpLiteral.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {RegExpLiteral, regExpLiteral, AnyNode} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {regExpLiteral, AnyNode} from '@romejs/js-ast';
 import {operator} from '@romejs/js-formatter/tokens';
 
 export default function RegExpLiteral(builder: Builder, node: AnyNode): Tokens {
@@ -41,7 +41,7 @@ export default function RegExpLiteral(builder: Builder, node: AnyNode): Tokens {
 
   return [
     operator('/'),
-    ...builder.tokenize(node.expression, node),
+    concat(builder.tokenize(node.expression, node)),
     operator(`/${flags.join('')}`),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/literals/TemplateLiteral.ts
+++ b/packages/@romejs/js-formatter/builders/literals/TemplateLiteral.ts
@@ -7,20 +7,20 @@
 
 import Builder from '../../Builder';
 import {TemplateLiteral, templateLiteral, AnyNode} from '@romejs/js-ast';
-import {Tokens} from '@romejs/js-formatter/tokens';
+import {Tokens, concat} from '@romejs/js-formatter/tokens';
 
 export default function TemplateLiteral(builder: Builder, node: AnyNode): Tokens {
   node = templateLiteral.assert(node);
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = [];
 
   const quasis = node.quasis;
 
   for (let i = 0; i < quasis.length; i++) {
-    tokens = tokens.concat(builder.tokenize(quasis[i], node));
+    tokens.push(concat(builder.tokenize(quasis[i], node)));
 
     if (i + 1 < quasis.length) {
-      tokens = tokens.concat(builder.tokenize(node.expressions[i], node));
+      tokens.push(concat(builder.tokenize(node.expressions[i], node)));
     }
   }
 

--- a/packages/@romejs/js-formatter/builders/modules/ExportAllDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportAllDeclaration.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space, operator} from '../../tokens';
-import {
-  ExportAllDeclaration,
-  exportAllDeclaration,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, word, space, operator, concat} from '../../tokens';
+import {exportAllDeclaration, AnyNode} from '@romejs/js-ast';
 
 export default function ExportAllDeclaration(
   builder: Builder,
@@ -26,7 +22,7 @@ export default function ExportAllDeclaration(
     space,
     word('from'),
     space,
-    ...builder.tokenize(node.source, node),
+    concat(builder.tokenize(node.source, node)),
     operator(';'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/modules/ExportDefaultDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportDefaultDeclaration.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space} from '../../tokens';
-import {
-  ExportDefaultDeclaration,
-  exportDefaultDeclaration,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, word, space, concat} from '../../tokens';
+import {exportDefaultDeclaration, AnyNode} from '@romejs/js-ast';
 import {_ExportDeclaration} from './ExportLocalDeclaration';
 
 export default function ExportDefaultDeclaration(
@@ -24,6 +20,6 @@ export default function ExportDefaultDeclaration(
     word('export'),
     word('default'),
     space,
-    ..._ExportDeclaration(builder, node),
+    concat(_ExportDeclaration(builder, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/modules/ExportExternalDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportExternalDeclaration.ts
@@ -6,12 +6,15 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, linkedGroups, operator, space, word} from '../../tokens';
 import {
-  AnyNode,
-  ExportExternalDeclaration,
-  exportExternalDeclaration,
-} from '@romejs/js-ast';
+  Tokens,
+  linkedGroups,
+  operator,
+  space,
+  word,
+  concat,
+} from '../../tokens';
+import {AnyNode, exportExternalDeclaration} from '@romejs/js-ast';
 import {printModuleSpecifiers} from './ImportDeclaration';
 
 export default function ExportExternalDeclaration(
@@ -29,12 +32,12 @@ export default function ExportExternalDeclaration(
 
   return [
     linkedGroups([
-      ...tokens,
-      ...printModuleSpecifiers(builder, node),
+      concat(tokens),
+      concat(printModuleSpecifiers(builder, node)),
       space,
       word('from'),
       space,
-      ...builder.tokenize(node.source, node),
+      concat(builder.tokenize(node.source, node)),
       operator(';'),
     ]),
   ];

--- a/packages/@romejs/js-formatter/builders/modules/ExportLocalDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportLocalDeclaration.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space, word} from '../../tokens';
-import {
-  ExportLocalDeclaration,
-  exportLocalDeclaration,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, space, word, concat} from '../../tokens';
+import {exportLocalDeclaration, AnyNode} from '@romejs/js-ast';
 import {isDeclaration} from '@romejs/js-ast-utils';
 
 export default function ExportLocalDeclaration(
@@ -24,7 +20,7 @@ export default function ExportLocalDeclaration(
     return [];
   }
 
-  return [word('export'), space, ..._ExportDeclaration(builder, node)];
+  return [word('export'), space, concat(_ExportDeclaration(builder, node))];
 }
 
 export function _ExportDeclaration(builder: Builder, node: AnyNode): Tokens {
@@ -44,10 +40,10 @@ export function _ExportDeclaration(builder: Builder, node: AnyNode): Tokens {
       throw new Error('Expected  ExportLocalDeclaration');
     }
 
-    let tokens: Tokens = [];
+    const tokens: Tokens = [];
 
     if (node.exportKind === 'type') {
-      tokens = [word('type'), space];
+      tokens.push(word('type'), space);
     }
 
     const {specifiers} = node;
@@ -56,7 +52,7 @@ export function _ExportDeclaration(builder: Builder, node: AnyNode): Tokens {
     }
 
     return [
-      ...tokens,
+      concat(tokens),
       operator('{'),
       builder.tokenizeCommaList(specifiers, node, {
         trailing: true,

--- a/packages/@romejs/js-formatter/builders/modules/ExportLocalSpecifier.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportLocalSpecifier.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, word} from '../../tokens';
+import {Tokens, space, word, concat} from '../../tokens';
 import {
   ExportLocalSpecifier,
   exportLocalSpecifier,
@@ -27,11 +27,11 @@ export default function ExportLocalSpecifier(
     return tokens;
   } else {
     return [
-      ...tokens,
+      concat(tokens),
       space,
       word('as'),
       space,
-      ...builder.tokenize(node.exported, node),
+      concat(builder.tokenize(node.exported, node)),
     ];
   }
 }

--- a/packages/@romejs/js-formatter/builders/modules/ExportNamespaceSpecifier.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ExportNamespaceSpecifier.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space, word} from '../../tokens';
-import {
-  ExportNamespaceSpecifier,
-  exportNamespaceSpecifier,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, space, word, concat} from '../../tokens';
+import {exportNamespaceSpecifier, AnyNode} from '@romejs/js-ast';
 
 export default function ExportNamespaceSpecifier(
   builder: Builder,
@@ -24,6 +20,6 @@ export default function ExportNamespaceSpecifier(
     space,
     word('as'),
     space,
-    ...builder.tokenize(node.exported, node),
+    concat(builder.tokenize(node.exported, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/modules/ImportCall.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ImportCall.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, operator} from '../../tokens';
-import {ImportCall, importCall, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, operator, concat} from '../../tokens';
+import {importCall, AnyNode} from '@romejs/js-ast';
 
 export default function ImportCall(builder: Builder, node: AnyNode): Tokens {
   node = importCall.assert(node);
@@ -15,7 +15,7 @@ export default function ImportCall(builder: Builder, node: AnyNode): Tokens {
   return [
     word('import'),
     operator('('),
-    ...builder.tokenize(node.argument, node),
+    concat(builder.tokenize(node.argument, node)),
     operator(')'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/modules/ImportDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ImportDeclaration.ts
@@ -6,7 +6,14 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, linkedGroups, space, operator} from '../../tokens';
+import {
+  Tokens,
+  word,
+  linkedGroups,
+  space,
+  operator,
+  concat,
+} from '../../tokens';
 import {
   ImportDeclaration,
   importDeclaration,
@@ -20,7 +27,7 @@ export default function ImportDeclaration(
 ): Tokens {
   node = importDeclaration.assert(node);
 
-  let tokens: Tokens = [word('import'), space];
+  const tokens: Tokens = [word('import'), space];
 
   if (node.importKind === 'type' || node.importKind === 'typeof') {
     tokens.push(word(node.importKind));
@@ -32,19 +39,18 @@ export default function ImportDeclaration(
   if (namedSpecifiers.length > 0 || namespaceSpecifier !== undefined ||
         defaultSpecifier !==
         undefined) {
-    tokens = [
-      ...tokens,
-      ...printModuleSpecifiers(builder, node),
+    tokens.push(
+      concat(printModuleSpecifiers(builder, node)),
       space,
       word('from'),
       space,
-    ];
+    );
   }
 
   return [
     linkedGroups([
-      ...tokens,
-      ...builder.tokenize(node.source, node),
+      concat(tokens),
+      concat(builder.tokenize(node.source, node)),
       operator(';'),
     ]),
   ];
@@ -62,15 +68,15 @@ export function printModuleSpecifiers(
     tokens = builder.tokenize(node.defaultSpecifier, node);
 
     if (namedSpecifiers.length > 0 || namespaceSpecifier !== undefined) {
-      tokens = [...tokens, operator(','), space];
+      tokens.push(operator(','), space);
     }
   }
 
   if (namespaceSpecifier !== undefined) {
-    tokens = [...tokens, ...builder.tokenize(namespaceSpecifier, node)];
+    tokens.push(concat(builder.tokenize(namespaceSpecifier, node)));
 
     if (namedSpecifiers.length > 0) {
-      tokens = [...tokens, operator(','), space];
+      tokens.push(operator(','), space);
     }
   }
 
@@ -78,8 +84,7 @@ export function printModuleSpecifiers(
     return tokens;
   } else {
     return [
-      ...tokens,
-
+      concat(tokens),
       operator('{'),
       builder.tokenizeCommaList(namedSpecifiers, node, {
         trailing: true,

--- a/packages/@romejs/js-formatter/builders/modules/ImportNamespaceSpecifier.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ImportNamespaceSpecifier.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space, word} from '../../tokens';
-import {
-  ImportNamespaceSpecifier,
-  importNamespaceSpecifier,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, space, word, concat} from '../../tokens';
+import {importNamespaceSpecifier, AnyNode} from '@romejs/js-ast';
 
 export default function ImportNamespaceSpecifier(
   builder: Builder,
@@ -24,6 +20,6 @@ export default function ImportNamespaceSpecifier(
     space,
     word('as'),
     space,
-    ...builder.tokenize(node.local.name, node),
+    concat(builder.tokenize(node.local.name, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/modules/ImportSpecifier.ts
+++ b/packages/@romejs/js-formatter/builders/modules/ImportSpecifier.ts
@@ -6,28 +6,25 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space} from '../../tokens';
+import {Tokens, word, space, concat} from '../../tokens';
 import {ImportSpecifier, importSpecifier, AnyNode} from '@romejs/js-ast';
 
 export default function ImportSpecifier(builder: Builder, node: AnyNode): Tokens {
   node = importSpecifier.assert(node);
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = [];
 
   if (node.local.importKind === 'type' || node.local.importKind === 'typeof') {
-    tokens = [word(node.local.importKind), space];
+    tokens.push(word(node.local.importKind), space);
   }
 
-  tokens = [...tokens, ...builder.tokenize(node.imported, node)];
+  tokens.push(concat(builder.tokenize(node.imported, node)));
 
   if (node.local.name.name !== node.imported.name) {
-    tokens = [
-      ...tokens,
-      space,
-      word('as'),
-      space,
-      ...builder.tokenize(node.local.name, node),
-    ];
+    tokens.push(space, word('as'), space, concat(builder.tokenize(
+      node.local.name,
+      node,
+    )));
   }
 
   return tokens;

--- a/packages/@romejs/js-formatter/builders/objects/ComputedPropertyKey.ts
+++ b/packages/@romejs/js-formatter/builders/objects/ComputedPropertyKey.ts
@@ -6,17 +6,17 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {
-  ComputedPropertyKey,
-  computedPropertyKey,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {computedPropertyKey, AnyNode} from '@romejs/js-ast';
 
 export default function ComputedPropertyKey(
   builder: Builder,
   node: AnyNode,
 ): Tokens {
   node = computedPropertyKey.assert(node);
-  return [operator('['), ...builder.tokenize(node.value, node), operator(']')];
+  return [
+    operator('['),
+    concat(builder.tokenize(node.value, node)),
+    operator(']'),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/objects/ObjectExpression.ts
+++ b/packages/@romejs/js-formatter/builders/objects/ObjectExpression.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator} from '../../tokens';
-import {ObjectExpression, objectExpression, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, operator, concat} from '../../tokens';
+import {objectExpression, AnyNode} from '@romejs/js-ast';
 
 export default function ObjectExpression(
   builder: Builder,
@@ -18,9 +18,9 @@ export default function ObjectExpression(
 
   const props = node.properties;
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     operator('{'),
-    ...builder.tokenizeInnerComments(node),
+    concat(builder.tokenizeInnerComments(node)),
     builder.tokenizeCommaList(props, node, {
       trailing: true,
       breakOnNewline: true,
@@ -30,10 +30,10 @@ export default function ObjectExpression(
   if ((node.type === 'BindingObjectPattern' || node.type ===
       'AssignmentObjectPattern') && node.rest !== undefined) {
     if (props.length > 0) {
-      tokens = [...tokens, operator(','), space];
+      tokens.push(operator(','), space);
     }
 
-    tokens = [...tokens, operator('...'), ...builder.tokenize(node.rest, node)];
+    tokens.push(operator('...'), concat(builder.tokenize(node.rest, node)));
   }
 
   tokens.push(operator('}'));

--- a/packages/@romejs/js-formatter/builders/objects/ObjectProperty.ts
+++ b/packages/@romejs/js-formatter/builders/objects/ObjectProperty.ts
@@ -6,13 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space} from '../../tokens';
-import {
-  ObjectProperty,
-  objectProperty,
-  AnyNode,
-  AnyObjectPropertyKey,
-} from '@romejs/js-ast';
+import {Tokens, operator, space, concat} from '../../tokens';
+import {objectProperty, AnyNode, AnyObjectPropertyKey} from '@romejs/js-ast';
 
 function isShorthand(key: AnyObjectPropertyKey, value: AnyNode): boolean {
   return key.type === 'StaticPropertyKey' && key.value.type === 'Identifier' &&
@@ -31,18 +26,18 @@ export default function ObjectProperty(builder: Builder, node: AnyNode): Tokens 
   if ((node.value.type === 'BindingAssignmentPattern' || node.value.type ===
       'AssignmentAssignmentPattern') && isShorthand(node.key, node.value.left)) {
     return [
-      ...tokens,
+      concat(tokens),
       space,
       operator('='),
       space,
-      ...builder.tokenize(node.value.right, node.value),
+      concat(builder.tokenize(node.value.right, node.value)),
     ];
   } else if (!isShorthand(node.key, node.value)) {
     return [
-      ...tokens,
+      concat(tokens),
       operator(':'),
       space,
-      ...builder.tokenize(node.value, node),
+      concat(builder.tokenize(node.value, node)),
     ];
   } else {
     return tokens;

--- a/packages/@romejs/js-formatter/builders/objects/SpreadProperty.ts
+++ b/packages/@romejs/js-formatter/builders/objects/SpreadProperty.ts
@@ -6,11 +6,11 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
-import {SpreadProperty, spreadProperty, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, concat} from '../../tokens';
+import {spreadProperty, AnyNode} from '@romejs/js-ast';
 
 export default function SpreadProperty(builder: Builder, node: AnyNode): Tokens {
   node = spreadProperty.assert(node);
 
-  return [operator('...'), ...builder.tokenize(node.argument, node)];
+  return [operator('...'), concat(builder.tokenize(node.argument, node))];
 }

--- a/packages/@romejs/js-formatter/builders/patterns/BindingArrayPattern.ts
+++ b/packages/@romejs/js-formatter/builders/patterns/BindingArrayPattern.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {
-  BindingArrayPattern,
-  bindingArrayPattern,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {bindingArrayPattern, AnyNode} from '@romejs/js-ast';
 import ArrayExpression from '../expressions/ArrayExpression';
 import {printPatternMeta} from '../utils';
 
@@ -22,7 +18,7 @@ export default function BindingArrayPattern(
   node = bindingArrayPattern.assert(node);
 
   return [
-    ...ArrayExpression(builder, node),
-    ...printPatternMeta(builder, node, node.meta),
+    concat(ArrayExpression(builder, node)),
+    concat(printPatternMeta(builder, node, node.meta)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/patterns/BindingAssignmentPattern.ts
+++ b/packages/@romejs/js-formatter/builders/patterns/BindingAssignmentPattern.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, operator} from '../../tokens';
+import {Tokens, space, operator, concat} from '../../tokens';
 import {
   BindingAssignmentPattern,
   bindingAssignmentPattern,
@@ -20,10 +20,10 @@ export default function BindingAssignmentPattern(
   node = bindingAssignmentPattern.assert(node);
 
   return [
-    ...builder.tokenize(node.left, node),
+    concat(builder.tokenize(node.left, node)),
     space,
     operator('='),
     space,
-    ...builder.tokenize(node.right, node),
+    concat(builder.tokenize(node.right, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/patterns/BindingIdentifier.ts
+++ b/packages/@romejs/js-formatter/builders/patterns/BindingIdentifier.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {BindingIdentifier, bindingIdentifier, AnyNode} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {bindingIdentifier, AnyNode} from '@romejs/js-ast';
 import Identifier from '../auxiliary/Identifier';
 import {printPatternMeta} from '../utils';
 
@@ -23,7 +23,7 @@ export default function BindingIdentifier(
   }
 
   return [
-    ...Identifier(builder, node),
-    ...printPatternMeta(builder, node, node.meta),
+    concat(Identifier(builder, node)),
+    concat(printPatternMeta(builder, node, node.meta)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/patterns/BindingObjectPattern.ts
+++ b/packages/@romejs/js-formatter/builders/patterns/BindingObjectPattern.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens} from '../../tokens';
-import {
-  BindingObjectPattern,
-  bindingObjectPattern,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, concat} from '../../tokens';
+import {bindingObjectPattern, AnyNode} from '@romejs/js-ast';
 import ObjectExpression from '../objects/ObjectExpression';
 import {printPatternMeta} from '../utils';
 
@@ -22,7 +18,7 @@ export default function BindingObjectPattern(
   node = bindingObjectPattern.assert(node);
 
   return [
-    ...ObjectExpression(builder, node),
-    ...printPatternMeta(builder, node, node.meta),
+    concat(ObjectExpression(builder, node)),
+    concat(printPatternMeta(builder, node, node.meta)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpAlternation.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpAlternation.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim} from '../../tokens';
-import {AnyNode, RegExpAlternation, regExpAlternation} from '@romejs/js-ast';
+import {Tokens, verbatim, concat} from '../../tokens';
+import {AnyNode, regExpAlternation} from '@romejs/js-ast';
 
 export default function RegExpAlternation(
   builder: Builder,
@@ -16,8 +16,8 @@ export default function RegExpAlternation(
   node = regExpAlternation.assert(node);
 
   return [
-    ...builder.tokenize(node.left, node),
+    concat(builder.tokenize(node.left, node)),
     verbatim('|'),
-    ...builder.tokenize(node.right, node),
+    concat(builder.tokenize(node.right, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpCharSet.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpCharSet.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim, flatten, concat} from '../../tokens';
+import {Tokens, verbatim, concat} from '../../tokens';
 import {AnyNode, regExpCharSet} from '@romejs/js-ast';
 
 export default function RegExpCharSet(builder: Builder, node: AnyNode): Tokens {
@@ -20,7 +20,7 @@ export default function RegExpCharSet(builder: Builder, node: AnyNode): Tokens {
 
   return [
     concat(tokens),
-    concat(flatten(node.body.map((item) => builder.tokenize(item, node)))),
+    concat(node.body.map((item) => concat(builder.tokenize(item, node)))),
     verbatim(']'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpCharSet.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpCharSet.ts
@@ -6,21 +6,21 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim, flatten} from '../../tokens';
-import {AnyNode, RegExpCharSet, regExpCharSet} from '@romejs/js-ast';
+import {Tokens, verbatim, flatten, concat} from '../../tokens';
+import {AnyNode, regExpCharSet} from '@romejs/js-ast';
 
 export default function RegExpCharSet(builder: Builder, node: AnyNode): Tokens {
   node = regExpCharSet.assert(node);
 
-  let tokens: Tokens = [verbatim('[')];
+  const tokens: Tokens = [verbatim('[')];
 
   if (node.invert) {
     tokens.push(verbatim('^'));
   }
 
   return [
-    ...tokens,
-    ...flatten(node.body.map((item) => builder.tokenize(item, node))),
+    concat(tokens),
+    concat(flatten(node.body.map((item) => builder.tokenize(item, node)))),
     verbatim(']'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpCharSetRange.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpCharSetRange.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim} from '../../tokens';
-import {AnyNode, RegExpCharSetRange, regExpCharSetRange} from '@romejs/js-ast';
+import {Tokens, verbatim, concat} from '../../tokens';
+import {AnyNode, regExpCharSetRange} from '@romejs/js-ast';
 
 export default function RegExpCharSetRange(
   builder: Builder,
@@ -16,8 +16,8 @@ export default function RegExpCharSetRange(
   node = regExpCharSetRange.assert(node);
 
   return [
-    ...builder.tokenize(node.start, node),
+    concat(builder.tokenize(node.start, node)),
     verbatim('-'),
-    ...builder.tokenize(node.end, node),
+    concat(builder.tokenize(node.end, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpCharacter.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpCharacter.ts
@@ -43,27 +43,21 @@ export default function RegExpCharacter(
   switch (node.value) {
     case '\t':
       return [verbatim('\\t')];
-      break;
 
     case '\n':
       return [verbatim('\\n')];
-      break;
 
     case '\r':
       return [verbatim('\\r')];
-      break;
 
     case '\x0b':
       return [verbatim('\\v')];
-      break;
 
     case '\f':
       return [verbatim('\\f')];
-      break;
 
     case '\b':
       return [verbatim('\\b')];
-      break;
 
     case '/':
     case '\\':

--- a/packages/@romejs/js-formatter/builders/regex/RegExpGroupCapture.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpGroupCapture.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim} from '../../tokens';
-import {AnyNode, RegExpGroupCapture, regExpGroupCapture} from '@romejs/js-ast';
+import {Tokens, verbatim, concat} from '../../tokens';
+import {AnyNode, regExpGroupCapture} from '@romejs/js-ast';
 
 export default function RegExpGroupCapture(
   builder: Builder,
@@ -23,5 +23,9 @@ export default function RegExpGroupCapture(
     tokens.push(verbatim('>'));
   }
 
-  return [...tokens, ...builder.tokenize(node.expression, node), verbatim(')')];
+  return [
+    concat(tokens),
+    concat(builder.tokenize(node.expression, node)),
+    verbatim(')'),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpGroupNonCapture.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpGroupNonCapture.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, verbatim} from '../../tokens';
-import {
-  AnyNode,
-  RegExpGroupNonCapture,
-  regExpGroupNonCapture,
-} from '@romejs/js-ast';
+import {Tokens, verbatim, concat} from '../../tokens';
+import {AnyNode, regExpGroupNonCapture} from '@romejs/js-ast';
 
 export default function RegExpGroupNonCapture(builder: Builder, node: AnyNode) {
   node = regExpGroupNonCapture.assert(node);
@@ -39,5 +35,9 @@ export default function RegExpGroupNonCapture(builder: Builder, node: AnyNode) {
       tokens.push(verbatim(':'));
   }
 
-  return [...tokens, ...builder.tokenize(node.expression, node), verbatim(')')];
+  return [
+    concat(tokens),
+    concat(builder.tokenize(node.expression, node)),
+    verbatim(')'),
+  ];
 }

--- a/packages/@romejs/js-formatter/builders/regex/RegExpSubExpression.ts
+++ b/packages/@romejs/js-formatter/builders/regex/RegExpSubExpression.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, flatten} from '../../tokens';
+import {Tokens, concat} from '../../tokens';
 import {
   AnyNode,
   RegExpSubExpression,
@@ -18,5 +18,5 @@ export default function RegExpSubExpression(
   node: AnyNode,
 ): Tokens {
   node = regExpSubExpression.assert(node);
-  return flatten(node.body.map((item) => builder.tokenize(item, node)));
+  return node.body.map((item) => concat(builder.tokenize(item, node)));
 }

--- a/packages/@romejs/js-formatter/builders/statements/BlockStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/BlockStatement.ts
@@ -6,13 +6,13 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, newline, indent, operator} from '../../tokens';
-import {BlockStatement, blockStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, newline, indent, operator, concat} from '../../tokens';
+import {blockStatement, AnyNode} from '@romejs/js-ast';
 
 export default function BlockStatement(builder: Builder, node: AnyNode): Tokens {
   node = blockStatement.assert(node);
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     operator('{'),
     indent(builder.tokenizeInnerComments(node)),
   ];
@@ -22,16 +22,12 @@ export default function BlockStatement(builder: Builder, node: AnyNode): Tokens 
       0);
 
   if (node.body.length > 0 || hasDirectives) {
-    tokens = [
-      ...tokens,
-      newline,
-      indent([
-        ...builder.tokenizeStatementList(node.directives, node),
-        // TODO newline here if hasDirectives
-        ...builder.tokenizeStatementList(node.body, node),
-      ]),
-    ];
+    tokens.push(newline, indent([
+      concat(builder.tokenizeStatementList(node.directives, node)),
+      // TODO newline here if hasDirectives
+      concat(builder.tokenizeStatementList(node.body, node)),
+    ]));
   }
 
-  return [...tokens, operator('}')];
+  return [concat(tokens), operator('}')];
 }

--- a/packages/@romejs/js-formatter/builders/statements/DoWhileStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/DoWhileStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space, operator} from '../../tokens';
-import {DoWhileStatement, doWhileStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, space, operator, concat} from '../../tokens';
+import {doWhileStatement, AnyNode} from '@romejs/js-ast';
 
 export default function DoWhileStatement(
   builder: Builder,
@@ -18,12 +18,12 @@ export default function DoWhileStatement(
   return [
     word('do'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
     space,
     word('while'),
     space,
     operator('('),
-    ...builder.tokenize(node.test, node),
+    concat(builder.tokenize(node.test, node)),
     operator(')'),
     operator(';'),
   ];

--- a/packages/@romejs/js-formatter/builders/statements/ExpressionStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/ExpressionStatement.ts
@@ -6,7 +6,7 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator} from '../../tokens';
+import {Tokens, operator, concat} from '../../tokens';
 import {
   ExpressionStatement,
   expressionStatement,
@@ -19,5 +19,5 @@ export default function ExpressionStatement(
 ): Tokens {
   node = expressionStatement.assert(node);
 
-  return [...builder.tokenize(node.expression, node), operator(';')];
+  return [concat(builder.tokenize(node.expression, node)), operator(';')];
 }

--- a/packages/@romejs/js-formatter/builders/statements/ForStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/ForStatement.ts
@@ -6,35 +6,36 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, word, space} from '../../tokens';
-import {ForStatement, forStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, word, space, concat} from '../../tokens';
+import {forStatement, AnyNode} from '@romejs/js-ast';
 
 export default function ForStatement(builder: Builder, node: AnyNode): Tokens {
   node = forStatement.assert(node);
 
   builder.inForStatementInitCounter++;
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     word('for'),
     space,
     operator('('),
-    ...builder.tokenize(node.init, node),
+    concat(builder.tokenize(node.init, node)),
     operator(';'),
   ];
   builder.inForStatementInitCounter--;
 
   if (node.test) {
-    tokens = [...tokens, space, ...builder.tokenize(node.test, node)];
+    tokens.push(space, concat(builder.tokenize(node.test, node)));
   }
+
   tokens.push(operator(';'));
 
   if (node.update) {
-    tokens = [...tokens, space, ...builder.tokenize(node.update, node)];
+    tokens.push(space, concat(builder.tokenize(node.update, node)));
   }
 
   return [
-    ...tokens,
+    concat(tokens),
     operator(')'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/statements/FunctionDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/statements/FunctionDeclaration.ts
@@ -7,11 +7,7 @@
 
 import Builder from '../../Builder';
 import {Tokens} from '../../tokens';
-import {
-  FunctionDeclaration,
-  functionDeclaration,
-  AnyNode,
-} from '@romejs/js-ast';
+import {functionDeclaration, AnyNode} from '@romejs/js-ast';
 import FunctionExpression from '../expressions/FunctionExpression';
 
 export default function FunctionDeclaration(

--- a/packages/@romejs/js-formatter/builders/statements/IfStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/IfStatement.ts
@@ -14,14 +14,15 @@ import {
   word,
   space,
   newline,
+  concat,
 } from '../../tokens';
-import {IfStatement, ifStatement, AnyNode} from '@romejs/js-ast';
+import {ifStatement, AnyNode} from '@romejs/js-ast';
 import {isStatement} from '@romejs/js-ast-utils';
 
 export default function IfStatement(builder: Builder, node: AnyNode): Tokens {
   node = ifStatement.assert(node);
 
-  let tokens: Tokens = [
+  const tokens: Tokens = [
     word('if'),
     space,
     operator('('),
@@ -35,26 +36,19 @@ export default function IfStatement(builder: Builder, node: AnyNode): Tokens {
     needsBlock = getLastStatement(node.consequent).type === 'IfStatement';
   }
   if (needsBlock) {
-    tokens = [
-      ...tokens,
-      operator('{'),
-      newline,
-      indent(builder.tokenize(node.consequent, node)),
-      newline,
-      operator('}'),
-    ];
+    tokens.push(operator('{'), newline, indent(builder.tokenize(
+      node.consequent,
+      node,
+    )), newline, operator('}'));
   } else {
-    tokens = [...tokens, ...builder.tokenize(node.consequent, node)];
+    tokens.push(concat(builder.tokenize(node.consequent, node)));
   }
 
   if (node.alternate) {
-    tokens = [
-      ...tokens,
-      space,
-      word('else'),
-      space,
-      ...builder.tokenize(node.alternate, node),
-    ];
+    tokens.push(space, word('else'), space, concat(builder.tokenize(
+      node.alternate,
+      node,
+    )));
   }
 
   return tokens;

--- a/packages/@romejs/js-formatter/builders/statements/LabeledStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/LabeledStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, operator, space} from '../../tokens';
-import {LabeledStatement, labeledStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, space, concat} from '../../tokens';
+import {labeledStatement, AnyNode} from '@romejs/js-ast';
 
 export default function LabeledStatement(
   builder: Builder,
@@ -16,9 +16,9 @@ export default function LabeledStatement(
   node = labeledStatement.assert(node);
 
   return [
-    ...builder.tokenize(node.label, node),
+    concat(builder.tokenize(node.label, node)),
     operator(':'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/statements/SwitchStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/SwitchStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space, operator} from '../../tokens';
-import {SwitchStatement, switchStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, space, operator, concat} from '../../tokens';
+import {switchStatement, AnyNode} from '@romejs/js-ast';
 
 export default function SwitchStatement(builder: Builder, node: AnyNode): Tokens {
   node = switchStatement.assert(node);
@@ -16,11 +16,11 @@ export default function SwitchStatement(builder: Builder, node: AnyNode): Tokens
     word('switch'),
     space,
     operator('('),
-    ...builder.tokenize(node.discriminant, node),
+    concat(builder.tokenize(node.discriminant, node)),
     operator(')'),
     space,
     operator('{'),
-    ...builder.tokenizeStatementList(node.cases, node, true),
+    concat(builder.tokenizeStatementList(node.cases, node, true)),
     operator('}'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/statements/TryStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/TryStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, space, word} from '../../tokens';
-import {TryStatement, tryStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, space, word, concat} from '../../tokens';
+import {tryStatement, AnyNode} from '@romejs/js-ast';
 
 export default function TryStatement(builder: Builder, node: AnyNode): Tokens {
   node = tryStatement.assert(node);
@@ -15,18 +15,18 @@ export default function TryStatement(builder: Builder, node: AnyNode): Tokens {
   const tokens: Tokens = [
     word('try'),
     space,
-    ...builder.tokenize(node.block, node),
+    concat(builder.tokenize(node.block, node)),
     space,
-    ...builder.tokenize(node.handler, node),
+    concat(builder.tokenize(node.handler, node)),
   ];
 
   if (node.finalizer) {
     return [
-      ...tokens,
+      concat(tokens),
       space,
       word('finally'),
       space,
-      ...builder.tokenize(node.finalizer, node),
+      concat(builder.tokenize(node.finalizer, node)),
     ];
   } else {
     return tokens;

--- a/packages/@romejs/js-formatter/builders/statements/VariableDeclarationStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/VariableDeclarationStatement.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {
-  VariableDeclarationStatement,
-  variableDeclarationStatement,
-  AnyNode,
-} from '@romejs/js-ast';
-import {Tokens, operator, word} from '@romejs/js-formatter/tokens';
+import {variableDeclarationStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, operator, word, concat} from '@romejs/js-formatter/tokens';
 
 export default function VariableDeclarationStatement(
   builder: Builder,
@@ -23,15 +19,15 @@ export default function VariableDeclarationStatement(
     return [];
   }
 
-  let tokens: Tokens = [];
+  const tokens: Tokens = [];
 
   if (node.declare) {
     tokens.push(word('declare'));
   }
 
   return [
-    ...tokens,
-    ...builder.tokenize(node.declaration, node),
+    concat(tokens),
+    concat(builder.tokenize(node.declaration, node)),
     operator(';'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/statements/WhileStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/WhileStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, operator, space} from '../../tokens';
-import {WhileStatement, whileStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, operator, space, concat} from '../../tokens';
+import {whileStatement, AnyNode} from '@romejs/js-ast';
 
 export default function WhileStatement(builder: Builder, node: AnyNode): Tokens {
   node = whileStatement.assert(node);
@@ -16,9 +16,9 @@ export default function WhileStatement(builder: Builder, node: AnyNode): Tokens 
     word('while'),
     space,
     operator('('),
-    ...builder.tokenize(node.test, node),
+    concat(builder.tokenize(node.test, node)),
     operator(')'),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/statements/WithStatement.ts
+++ b/packages/@romejs/js-formatter/builders/statements/WithStatement.ts
@@ -6,8 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space, operator} from '../../tokens';
-import {WithStatement, withStatement, AnyNode} from '@romejs/js-ast';
+import {Tokens, word, space, operator, concat} from '../../tokens';
+import {withStatement, AnyNode} from '@romejs/js-ast';
 
 export default function WithStatement(builder: Builder, node: AnyNode): Tokens {
   node = withStatement.assert(node);
@@ -16,8 +16,8 @@ export default function WithStatement(builder: Builder, node: AnyNode): Tokens {
     word('with'),
     space,
     operator('('),
-    ...builder.tokenize(node.object, node),
+    concat(builder.tokenize(node.object, node)),
     operator(')'),
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/types/TypeAliasTypeAnnotation.ts
+++ b/packages/@romejs/js-formatter/builders/types/TypeAliasTypeAnnotation.ts
@@ -6,12 +6,8 @@
  */
 
 import Builder from '../../Builder';
-import {Tokens, word, space, operator} from '../../tokens';
-import {
-  TypeAliasTypeAnnotation,
-  typeAliasTypeAnnotation,
-  AnyNode,
-} from '@romejs/js-ast';
+import {Tokens, word, space, operator, concat} from '../../tokens';
+import {typeAliasTypeAnnotation, AnyNode} from '@romejs/js-ast';
 
 export default function TypeAliasTypeAnnotation(
   builder: Builder,
@@ -22,12 +18,12 @@ export default function TypeAliasTypeAnnotation(
   return [
     word('type'),
     space,
-    ...builder.tokenize(node.id, node),
-    ...builder.tokenize(node.typeParameters, node),
+    concat(builder.tokenize(node.id, node)),
+    concat(builder.tokenize(node.typeParameters, node)),
     space,
     operator('='),
     space,
-    ...builder.tokenize(node.right, node),
+    concat(builder.tokenize(node.right, node)),
     operator(';'),
   ];
 }

--- a/packages/@romejs/js-formatter/builders/utils.ts
+++ b/packages/@romejs/js-formatter/builders/utils.ts
@@ -24,6 +24,7 @@ import {
   space,
   terminatorless,
   breakGroup,
+  concat,
 } from '../tokens';
 
 export function buildForXStatementBuilder(op: 'of' | 'in'): BuilderMethod {
@@ -38,16 +39,16 @@ export function buildForXStatementBuilder(op: 'of' | 'in'): BuilderMethod {
     }
 
     return [
-      ...tokens,
+      concat(tokens),
       operator('('),
-      ...builder.tokenize(node.left, node),
+      concat(builder.tokenize(node.left, node)),
       space,
       word(op),
       space,
-      ...builder.tokenize(node.right, node),
+      concat(builder.tokenize(node.right, node)),
       operator(')'),
       space,
-      ...builder.tokenize(node.body, node),
+      concat(builder.tokenize(node.body, node)),
     ];
   };
 }
@@ -66,7 +67,7 @@ export function buildYieldAwaitBuilder(keyword: string): BuilderMethod {
 
       if (node.argument) {
         return [
-          ...tokens,
+          concat(tokens),
           space,
           terminatorless(builder.tokenize(node.argument, node)),
         ];
@@ -82,12 +83,12 @@ export function buildLabelStatementBuilder(prefix: string): BuilderMethod {
         node.type === 'ContinueStatement' || node.type === 'ReturnStatement' ||
         node.type === 'BreakStatement' ? node : throwStatement.assert(node);
 
-    let tokens: Tokens = [word(prefix)];
+    const tokens: Tokens = [word(prefix)];
 
     if ((node.type === 'ContinueStatement' || node.type === 'BreakStatement') &&
         node.label !== undefined) {
       tokens.push(space);
-      tokens = tokens.concat(builder.tokenize(node.label, node));
+      tokens.push(concat(builder.tokenize(node.label, node)));
     }
 
     if ((node.type === 'ThrowStatement' || node.type === 'ReturnStatement') &&
@@ -128,15 +129,15 @@ export function printMethod(
   }
 
   if (node.type === 'TSDeclareMethod') {
-    return [...tokens, ...builder.tokenize(node.head, node)];
+    return [concat(tokens), concat(builder.tokenize(node.head, node))];
   }
 
   return [
-    ...tokens,
-    ...builder.tokenize(node.key, node),
-    ...builder.tokenize(node.head, node),
+    concat(tokens),
+    concat(builder.tokenize(node.key, node)),
+    concat(builder.tokenize(node.head, node)),
     space,
-    ...builder.tokenize(node.body, node),
+    concat(builder.tokenize(node.body, node)),
   ];
 }
 
@@ -151,7 +152,7 @@ export function printBindingPatternParams(
   });
 
   if (rest !== undefined) {
-    group.groups.push([operator('...'), ...builder.tokenize(rest, node)]);
+    group.groups.push([operator('...'), concat(builder.tokenize(rest, node))]);
   }
 
   return [group];
@@ -184,12 +185,15 @@ export function printPatternMeta(
   meta: undefined | PatternMeta,
 ): Tokens {
   if (builder.options.typeAnnotations && meta !== undefined) {
-    let tokens: Tokens = [];
+    const tokens: Tokens = [];
     if (meta.optional) {
       tokens.push(operator('?'));
     }
 
-    return [...tokens, ...builder.tokenizeTypeColon(meta.typeAnnotation, node)];
+    return [
+      concat(tokens),
+      concat(builder.tokenizeTypeColon(meta.typeAnnotation, node)),
+    ];
   } else {
     return [];
   }

--- a/packages/@romejs/js-formatter/tokens.ts
+++ b/packages/@romejs/js-formatter/tokens.ts
@@ -238,13 +238,3 @@ export function concat(tokens: Tokens): ConcatToken {
     tokens,
   };
 }
-
-export function flatten(arr: Array<Tokens>): Tokens {
-  let tokens: Tokens = [];
-
-  for (const elem of arr) {
-    tokens = tokens.concat(elem);
-  }
-
-  return tokens;
-}

--- a/packages/@romejs/js-formatter/tokens.ts
+++ b/packages/@romejs/js-formatter/tokens.ts
@@ -94,6 +94,11 @@ export type PositionMarkerToken = {
   location: SourceLocation;
 };
 
+export type ConcatToken = {
+  type: 'ConcatToken';
+  tokens: Tokens;
+};
+
 export type Token =
   | GroupToken
   | IndentToken
@@ -107,7 +112,8 @@ export type Token =
   | TerminatorlessToken
   | CommentToken
   | WordToken
-  | PositionMarkerToken;
+  | PositionMarkerToken
+  | ConcatToken;
 
 export type Tokens = Array<Token>;
 
@@ -223,6 +229,13 @@ export function positionMarker(
     type: 'PositionMarker',
     tokens,
     location,
+  };
+}
+
+export function concat(tokens: Tokens): ConcatToken {
+  return {
+    type: 'ConcatToken',
+    tokens,
   };
 }
 


### PR DESCRIPTION
Instead of spreading tokens together, this PR adds a new way to glue the tokens using a `ConcatToken`. It is wrapper around the token array so it prevents useless copies or iterator drains.

**Note:** This PR may look hard to review but the logic is split between the 2 first commits.