### PR TITLE
Fix markup escaping and windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "romeLSPBin": "./scripts/vendor-rome",
   "scripts": {
-    "dev-rome": "./scripts/dev-rome",
-    "test": "./scripts/dev-rome test",
-    "lint": "./scripts/dev-rome lint",
-    "fix": "./scripts/dev-rome --fix"
+    "dev-rome": "node ./scripts/dev-rome",
+    "test": "node ./scripts/dev-rome test",
+    "lint": "node ./scripts/dev-rome lint",
+    "fix": "node ./scripts/dev-rome --fix"
   },
   "rome": {
     "root": true,

--- a/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
@@ -24,7 +24,11 @@ import {
   DiagnosticsFileReaderStats,
 } from './types';
 
-import {humanizeMarkupFilename, formatAnsi} from '@romejs/string-markup';
+import {
+  humanizeMarkupFilename,
+  formatAnsi,
+  markup,
+} from '@romejs/string-markup';
 import {toLines} from './utils';
 import printAdvice from './printAdvice';
 
@@ -470,7 +474,7 @@ export default class DiagnosticsPrinter extends Error {
         outdatedAdvice.push({
           type: 'list',
           list: outdatedFilesArr.map(
-            (filename) => `<filelink target="${filename}" />`,
+            (filename) => markup`<filelink target="${filename}" />`,
           ),
         });
       }

--- a/packages/@romejs/cli-diagnostics/index.ts
+++ b/packages/@romejs/cli-diagnostics/index.ts
@@ -60,6 +60,7 @@ export function printDiagnosticsToString({
       {
         type: 'all',
         format,
+        unicode: true,
         columns: 400,
         write(chunk) {
           buff += chunk;

--- a/packages/@romejs/cli-diagnostics/printAdvice.ts
+++ b/packages/@romejs/cli-diagnostics/printAdvice.ts
@@ -20,7 +20,7 @@ import {
   getDiagnosticHeader,
 } from '@romejs/diagnostics';
 import {Position} from '@romejs/parser-core';
-import {toLines} from './utils';
+import {toLines, showInvisibles} from './utils';
 import buildPatchCodeFrame from './buildPatchCodeFrame';
 import buildMessageCodeFrame from './buildMessageCodeFrame';
 import {escapeMarkup, markupTag} from '@romejs/string-markup';
@@ -227,7 +227,14 @@ function printCode(
 
   reporter.indent(
     () => {
-      reporter.logAll(escapeMarkup(code));
+      if (code === '') {
+        reporter.logAll('<dim>empty input</dim>');
+      } else if (code.trim() === '') {
+        // If it's a string with only whitespace then make it obvious
+        reporter.logAll(showInvisibles(code));
+      } else {
+        reporter.logAll(escapeMarkup(code));
+      }
 
       if (truncated) {
         reporter.logAll(

--- a/packages/@romejs/cli-reporter/Progress.ts
+++ b/packages/@romejs/cli-reporter/Progress.ts
@@ -13,7 +13,7 @@ import {
   ReporterProgressOptions,
 } from './types';
 import ProgressBase from './ProgressBase';
-import {markupTag, ansiEscapes} from '@romejs/string-markup';
+import {markupTag, ansiEscapes, escapeMarkup} from '@romejs/string-markup';
 
 type BoldRanges = Array<[number, number]>;
 
@@ -261,16 +261,17 @@ export default class Progress extends ProgressBase {
     let start = this.getBouncerPosition(stream);
     let fullBar = '';
     for (const [i, char] of bar) {
+      const escaped = escapeMarkup(char);
       const isBounce = i >= start && i < start + BOUNCER_WIDTH;
 
       if (isBounce) {
         if (this.paused) {
-          fullBar += markupTag('inverse', char);
+          fullBar += markupTag('inverse', escaped);
         } else {
-          fullBar += markupTag('white', markupTag('bgYellow', char));
+          fullBar += markupTag('white', markupTag('bgYellow', escaped));
         }
       } else {
-        fullBar += char;
+        fullBar += escaped;
       }
     }
     return fullBar;

--- a/packages/@romejs/cli-reporter/types.ts
+++ b/packages/@romejs/cli-reporter/types.ts
@@ -15,6 +15,7 @@ export type Package = {
 export type ReporterStream = {
   type: 'out' | 'error' | 'all';
   columns: number;
+  unicode: boolean;
   format: 'ansi' | 'html' | 'none';
   write: (chunk: string) => void;
   teardown?: () => void;

--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -31,7 +31,7 @@ import {commandCategories} from '@romejs/core/commands';
 import {writeFile} from '@romejs/fs';
 import fs = require('fs');
 
-import {stripAnsi} from '@romejs/string-markup';
+import {stripAnsi, markup} from '@romejs/string-markup';
 import {Dict} from '@romejs/typescript-helpers';
 
 type CLIFlags = {
@@ -281,7 +281,7 @@ export default async function cli() {
             await writeFile(resolvedProfilePath, str);
 
             client.reporter.success(
-              `Wrote CPU profile to <filelink emphasis target="${resolvedProfilePath.join()}" />`,
+              markup`Wrote CPU profile to <filelink emphasis target="${resolvedProfilePath.join()}" />`,
             );
           },
         );
@@ -340,7 +340,7 @@ export default async function cli() {
       await writeFile(markersPath, JSON.stringify(res.markers, null, '  '));
 
       client.reporter.success(
-        `Wrote markers to <filelink emphasis target="${markersPath.join()}" />`,
+        markup`Wrote markers to <filelink emphasis target="${markersPath.join()}" />`,
       );
     }
   }

--- a/packages/@romejs/core/client/Client.ts
+++ b/packages/@romejs/core/client/Client.ts
@@ -424,6 +424,7 @@ export default class Client {
       bridge.getClientInfo.wait({
         version: VERSION,
         format: stdout.format,
+        unicode: stdout.unicode,
         hasClearScreen: this.reporter.hasClearScreen,
         columns: stdout.columns,
         useRemoteReporter: true,

--- a/packages/@romejs/core/common/bridges/MasterBridge.ts
+++ b/packages/@romejs/core/common/bridges/MasterBridge.ts
@@ -75,6 +75,7 @@ export type MasterBridgeInfo = {
   columns: number;
   hasClearScreen: boolean;
   useRemoteReporter: boolean;
+  unicode: boolean;
   format: ReporterStream['format'];
   flags: ClientFlagsJSON;
 };

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -138,6 +138,7 @@ export default class Master {
           type: 'all',
           format: 'none',
           columns: 0,
+          unicode: true,
           write: (chunk) => {
             this.emitMasterLog(chunk);
           },
@@ -388,6 +389,7 @@ export default class Master {
       useRemoteReporter,
       hasClearScreen,
       columns,
+      unicode,
       format,
       version,
     } = await bridge.getClientInfo.call();
@@ -402,6 +404,7 @@ export default class Master {
       type: 'out',
       columns,
       format,
+      unicode,
       write(chunk: string) {
         if (flags.silent === true) {
           return;

--- a/packages/@romejs/core/master/MasterRequest.ts
+++ b/packages/@romejs/core/master/MasterRequest.ts
@@ -71,6 +71,7 @@ import {createErrorFromStructure, getErrorStructure} from '@romejs/v8';
 import {Dict, RequiredProps} from '@romejs/typescript-helpers';
 import {number1, number0, coerce0} from '@romejs/ob1';
 import {MemoryFSGlobOptions} from './fs/MemoryFileSystem';
+import {markup} from '@romejs/string-markup';
 
 type MasterRequestOptions = {
   master: Master;
@@ -546,9 +547,9 @@ export default class MasterRequest {
       for (const {path, project, location} of noArgMatches) {
         let category: DiagnosticCategory = 'args/fileNotFound';
 
-        let advice: DiagnosticAdvice = opts.advice === undefined ? [] : [
-          ...opts.advice,
-        ];
+        let advice: DiagnosticAdvice = opts.advice === undefined
+          ? []
+          : [...opts.advice];
 
         // Hint if `path` failed `globOpts.test`
         if (configCategory !== undefined &&
@@ -743,7 +744,7 @@ export default class MasterRequest {
                 {
                   type: 'log',
                   category: 'info',
-                  message: `Error occurred while requesting ${method} for <filelink emphasis target="${ref.uid}" />`,
+                  message: markup`Error occurred while requesting ${method} for <filelink emphasis target="${ref.uid}" />`,
                 },
               ],
             },

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -27,6 +27,7 @@ import {WorkerCompileResult} from '../../common/bridges/WorkerBridge';
 import {Dict} from '@romejs/typescript-helpers';
 import {readFile} from '@romejs/fs';
 import {flipPathPatterns} from '@romejs/path-match';
+import {markup} from '@romejs/string-markup';
 
 export type BundlerEntryResoluton = {
   manifestDef: undefined | ManifestDefinition;
@@ -170,7 +171,7 @@ export default class Bundler {
       }
 
       const promise = (async () => {
-        const text = `<filelink target="${entry.join()}" />`;
+        const text = markup`<filelink target="${entry.join()}" />`;
         progress.pushText(text);
         map.set(entry, await this.bundle(entry, {}, silentReporter));
         progress.popText(text);
@@ -337,7 +338,7 @@ export default class Bundler {
     reporter: Reporter = this.reporter,
   ): Promise<BundleResult> {
     reporter.info(
-      `Bundling <filelink emphasis target="${resolvedEntry.join()}" />`,
+      markup`Bundling <filelink emphasis target="${resolvedEntry.join()}" />`,
     );
 
     const req = this.createBundleRequest(resolvedEntry, options, reporter);

--- a/packages/@romejs/core/master/commands/bundle.ts
+++ b/packages/@romejs/core/master/commands/bundle.ts
@@ -10,6 +10,7 @@ import {commandCategories, createMasterCommand} from '../../commands';
 import Bundler from '../bundler/Bundler';
 import {createDirectory, writeFile} from '@romejs/fs';
 import {Consumer} from '@romejs/consume';
+import {markup} from '@romejs/string-markup';
 
 type Flags = {quiet: boolean};
 
@@ -45,7 +46,7 @@ export default createMasterCommand<Flags>(
         const file = dir.append(filename);
         const loc = file.join();
         savedList.push(
-          `<filelink target="${loc}">${filename}</filelink> <filesize dim>${Buffer.byteLength(
+          markup`<filelink target="${loc}">${filename}</filelink> <filesize dim>${Buffer.byteLength(
             content,
           )}</filesize> <inverse>${kind}</inverse>`,
         );
@@ -54,10 +55,10 @@ export default createMasterCommand<Flags>(
       }
 
       if (commandFlags.quiet) {
-        reporter.success(`Saved to <filelink target="${dir.join()}" />`);
+        reporter.success(markup`Saved to <filelink target="${dir.join()}" />`);
       } else {
         reporter.success(
-          `Saved the following files to <filelink target="${dir.join()}" />`,
+          markup`Saved the following files to <filelink target="${dir.join()}" />`,
         );
         reporter.list(savedList);
       }

--- a/packages/@romejs/core/master/commands/config.ts
+++ b/packages/@romejs/core/master/commands/config.ts
@@ -10,6 +10,7 @@ import {createMasterCommand, commandCategories} from '../../commands';
 
 import {modifyProjectConfig, assertHardMeta} from '@romejs/project';
 import {createUnknownFilePath} from '@romejs/path';
+import {markup} from '@romejs/string-markup';
 
 export default createMasterCommand(
   {
@@ -103,7 +104,7 @@ export default createMasterCommand(
           {
             pre: (meta) => {
               reporter.success(
-                `Setting <emphasis>${keyParts}</emphasis> to <emphasis>${JSON.stringify(
+                markup`Setting <emphasis>${keyParts}</emphasis> to <emphasis>${JSON.stringify(
                   value,
                 )}</emphasis> in the project config <filelink emphasis target="${meta.configPath.join()}" />`,
               );
@@ -111,9 +112,9 @@ export default createMasterCommand(
               if (value === 'true' || value === 'false') {
                 const suggestedCommand = value === 'true' ? 'enable' : 'disable';
                 reporter.warn(
-                  `Value is the string <emphasis>${value}</emphasis> but it looks like a boolean. You probably meant to use the command:`,
+                  markup`Value is the string <emphasis>${value}</emphasis> but it looks like a boolean. You probably meant to use the command:`,
                 );
-                reporter.command(`config ${suggestedCommand} ${keyParts}`);
+                reporter.command(markup`config ${suggestedCommand} ${keyParts}`);
               }
             },
 

--- a/packages/@romejs/core/master/commands/lint.ts
+++ b/packages/@romejs/core/master/commands/lint.ts
@@ -10,6 +10,7 @@ import {createMasterCommand, commandCategories} from '../../commands';
 import Linter, {LinterOptions} from '../linter/Linter';
 
 import {Consumer} from '@romejs/consume';
+import {markup} from '@romejs/string-markup';
 
 type Flags = {
   fix: boolean;
@@ -53,7 +54,7 @@ export default createMasterCommand<Flags>({
         reporter.warn(`No files changed from <emphasis>${target}</emphasis>`);
       } else {
         reporter.info(`Files changed from <emphasis>${target}</emphasis>`);
-        reporter.list(args.map((arg) => `<filelink target="${arg}" />`));
+        reporter.list(args.map((arg) => markup`<filelink target="${arg}" />`));
         reporter.hr();
       }
     }

--- a/packages/@romejs/core/master/dependencies/DependencyGraph.ts
+++ b/packages/@romejs/core/master/dependencies/DependencyGraph.ts
@@ -24,6 +24,7 @@ import {
   AbsoluteFilePathMap,
 } from '@romejs/path';
 import {AnalyzeModuleType} from '../../common/types/analyzeDependencies';
+import {markup} from '@romejs/string-markup';
 
 export type DependencyGraphSeedResult = {
   node: DependencyNode;
@@ -258,7 +259,7 @@ export default class DependencyGraph {
       return node;
     }
 
-    const progressText = `<filelink target="${filename}" />`;
+    const progressText = markup`<filelink target="${filename}" />`;
 
     if (analyzeProgress !== undefined) {
       analyzeProgress.pushText(progressText);

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -48,6 +48,7 @@ import {
   getFileHandler,
   getFileHandlerExtensions,
 } from '../../common/fileHandlers';
+import {markup} from '@romejs/string-markup';
 
 const DEFAULT_DENYLIST = ['.hg', '.git'];
 
@@ -657,6 +658,7 @@ export default class MemoryFileSystem {
   ): Promise<void> {
     const {logger} = this.master;
     const projectFolder = projectFolderPath.join();
+    const folderLink = markup`<filelink target="${projectFolder}" />`;
 
     // Defer if we're already currently initializing this project
     const cached = this.watchPromises.get(projectFolder);
@@ -674,7 +676,7 @@ export default class MemoryFileSystem {
     for (const {path} of this.watchers.values()) {
       if (projectFolderPath.isRelativeTo(path)) {
         logger.info(
-          `[MemoryFileSystem] Skipped crawl for ${projectFolder} because we're already watching the parent directory ${path.join()}`,
+          `[MemoryFileSystem] Skipped crawl for ${folderLink} because we're already watching the parent directory ${path.join()}`,
         );
         return undefined;
       }
@@ -684,7 +686,7 @@ export default class MemoryFileSystem {
     await this.waitIfInitializingWatch(projectFolderPath);
 
     // New watch target
-    logger.info(`[MemoryFileSystem] Adding new project folder ${projectFolder}`);
+    logger.info(`[MemoryFileSystem] Adding new project folder ${folderLink}`);
 
     // Remove watchers that are descedents of this folder as this watcher will handle them
     for (const [loc, {close, path}] of this.watchers) {
@@ -705,7 +707,7 @@ export default class MemoryFileSystem {
 
     let promise;
     if (projectConfig.files.watchman) {
-      logger.info(`[MemoryFileSystem] Watching ${projectFolder} with watchman`);
+      logger.info(`[MemoryFileSystem] Watching ${folderLink} with watchman`);
       promise = createWatchmanWatcher(
         this,
         diagnostics,
@@ -713,7 +715,7 @@ export default class MemoryFileSystem {
         projectConfig,
       );
     } else {
-      logger.info(`[MemoryFileSystem] Watching ${projectFolder} with fs.watch`);
+      logger.info(`[MemoryFileSystem] Watching ${folderLink} with fs.watch`);
       promise = createRegularWatcher(this, diagnostics, projectFolderPath);
     }
     this.watchPromises.set(projectFolder, {

--- a/packages/@romejs/core/master/fs/resolverSuggest.ts
+++ b/packages/@romejs/core/master/fs/resolverSuggest.ts
@@ -24,6 +24,7 @@ import {
 import {orderBySimilarity} from '@romejs/string-utils';
 import {createUnknownFilePath, AbsoluteFilePath} from '@romejs/path';
 import {PLATFORMS} from '../../common/types/platform';
+import {markup} from '@romejs/string-markup';
 
 export default function resolverSuggest(
   resolver: Resolver,
@@ -110,7 +111,7 @@ export default function resolverSuggest(
 
       if (resolved.type === 'FOUND') {
         validPlatforms.push(
-          `<emphasis>${PLATFORM}</emphasis> at <filelink emphasis target="${resolved.ref.uid}" />`,
+          markup`<emphasis>${PLATFORM}</emphasis> at <filelink emphasis target="${resolved.ref.uid}" />`,
         );
       }
     }
@@ -128,7 +129,7 @@ export default function resolverSuggest(
           {
             type: 'log',
             category: 'info',
-            message: `No module found for the platform <emphasis>${query.platform}</emphasis> but we found these others`,
+            message: markup`No module found for the platform <emphasis>${query.platform}</emphasis> but we found these others`,
           },
         );
       }
@@ -193,19 +194,24 @@ export default function resolverSuggest(
           },
         );
 
-        advice = [
-          ...advice,
-          ...buildSuggestionAdvice(query.source.join(), relativeSuggestions, {
-            formatItem: (relative) => {
-              const absolute = relativeToAbsolute.get(relative);
-              if (absolute === undefined) {
-                throw new Error('Should be valid');
-              }
+          advice =
+          [
+            ...advice,
+            ...buildSuggestionAdvice(
+              query.source.join(),
+              relativeSuggestions,
+              {
+                formatItem: (relative) => {
+                  const absolute = relativeToAbsolute.get(relative);
+                  if (absolute === undefined) {
+                    throw new Error('Should be valid');
+                  }
 
-              return `<filelink target="${absolute}">${relative}</filelink>`;
-            },
-          }),
-        ];
+                  return markup`<filelink target="${absolute}">${relative}</filelink>`;
+                },
+              },
+            ),
+          ];
       }
     }
 
@@ -243,7 +249,7 @@ export default function resolverSuggest(
   }
 
     message +=
-    ` <emphasis>${source}</emphasis> from <filelink emphasis target="${location.filename}" />`;
+    markup` <emphasis>${source}</emphasis> from <filelink emphasis target="${location.filename}" />`;
 
   throw createSingleDiagnosticError({
     location,

--- a/packages/@romejs/core/master/linter/Linter.ts
+++ b/packages/@romejs/core/master/linter/Linter.ts
@@ -23,6 +23,7 @@ import DependencyGraph from '../dependencies/DependencyGraph';
 import {ReporterProgressOptions, ReporterProgress} from '@romejs/cli-reporter';
 import DependencyNode from '../dependencies/DependencyNode';
 import {areAnalyzeDependencyResultsEqual} from '@romejs/js-compiler';
+import {markup} from '@romejs/string-markup';
 
 type LintWatchChanges = Array<{
   filename: undefined | string;
@@ -163,7 +164,7 @@ class LintRunner {
 
     await Promise.all(pathsByWorker.map(async (paths) => {
       for (const path of paths) {
-        const text = `<filelink target="${path.join()}" />`;
+        const text = markup`<filelink target="${path.join()}" />`;
         progress.pushText(text);
 
         const {

--- a/packages/@romejs/core/master/testing/TestRunner.ts
+++ b/packages/@romejs/core/master/testing/TestRunner.ts
@@ -46,7 +46,7 @@ import {
   CoverageFolder,
 } from './types';
 import {percentInsideCoverageFolder, formatPercent, sortMapKeys} from './utils';
-import {escapeMarkup} from '@romejs/string-markup';
+import {escapeMarkup, markup} from '@romejs/string-markup';
 
 class BridgeStructuredError extends NativeStructuredError {
   constructor(struct: Partial<StructuredError>, bridge: Bridge) {
@@ -58,7 +58,9 @@ class BridgeStructuredError extends NativeStructuredError {
 }
 
 function getProgressTestRefText(ref: TestRef) {
-  return `<filelink target="${ref.filename}" />: ${escapeMarkup(ref.testName)}`;
+  return markup`<filelink target="${ref.filename}" />: ${escapeMarkup(
+    ref.testName,
+  )}`;
 }
 
 export default class TestRunner {
@@ -548,7 +550,7 @@ export default class TestRunner {
               createAbsoluteFilePath(ref.filename),
             );
               origin.message =
-              `Generated from the file <filelink target="${uid}" /> and test name "${ref.testName}"`;
+              markup`Generated from the file <filelink target="${uid}" /> and test name "${ref.testName}"`;
             this.onTestFinished(ref);
             progress.popText(getProgressTestRefText(ref));
             progress.tick();
@@ -689,12 +691,15 @@ export default class TestRunner {
           absolute = absolutePath.join();
         }
 
-        rows.push([
-          fileIndent + `<filelink target="${absolute}">${name}</filelink>`,
-          formatPercent(file.functions.percent),
-          formatPercent(file.branches.percent),
-          formatPercent(file.lines.percent),
-        ]);
+        rows.push(
+          [
+              fileIndent +
+              markup`<filelink target="${absolute}">${name}</filelink>`,
+            formatPercent(file.functions.percent),
+            formatPercent(file.branches.percent),
+            formatPercent(file.lines.percent),
+          ],
+        );
       }
 
       for (const subFolder of sortMapKeys(folder.folders).values()) {

--- a/packages/@romejs/core/master/web/index.ts
+++ b/packages/@romejs/core/master/web/index.ts
@@ -91,6 +91,7 @@ export class WebServer {
         type: 'all',
         format: 'ansi',
         columns: 100,
+        unicode: true,
         write(chunk) {
           data.stdoutAnsi += chunk;
         },
@@ -100,6 +101,7 @@ export class WebServer {
         type: 'all',
         format: 'html',
         columns: 100,
+        unicode: true,
         write(chunk) {
           data.stdoutAnsi += chunk;
         },

--- a/packages/@romejs/core/test-worker/TestAPI.ts
+++ b/packages/@romejs/core/test-worker/TestAPI.ts
@@ -490,7 +490,7 @@ export default class TestAPI {
           {
             type: 'log',
             category: 'info',
-            message: `Snapshot can be found at <filelink emphasis target="${this.snapshotManager.path.join()}" />`,
+            message: markup`Snapshot can be found at <filelink emphasis target="${this.snapshotManager.path.join()}" />`,
           },
         );
       }

--- a/packages/@romejs/core/test-worker/TestWorkerRunner.ts
+++ b/packages/@romejs/core/test-worker/TestWorkerRunner.ts
@@ -30,6 +30,7 @@ import {
   convertTransportFileReference,
 } from '../common/types/files';
 import {createAbsoluteFilePath, AbsoluteFilePath} from '@romejs/path';
+import {markup} from '@romejs/string-markup';
 
 const MAX_RUNNING_TESTS = 20;
 
@@ -391,7 +392,7 @@ export default class TestWorkerRunner {
               {
                 type: 'log',
                 category: 'info',
-                message: `Error occured while executing test file <filelink emphasis target="${this.file.uid}" />`,
+                message: markup`Error occured while executing test file <filelink emphasis target="${this.file.uid}" />`,
               },
               INTERNAL_ERROR_LOG_ADVICE,
             ],

--- a/packages/@romejs/core/worker/Worker.ts
+++ b/packages/@romejs/core/worker/Worker.ts
@@ -68,6 +68,7 @@ export default class Worker {
           type: 'all',
           format: 'none',
           columns: Reporter.DEFAULT_COLUMNS,
+          unicode: true,
           write(chunk) {
             opts.bridge.log.send(chunk.toString());
           },

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -509,7 +509,7 @@ export const descriptions = createMessages(
           {
             type: 'log',
             category: 'info',
-            message: `Defined already by <filelink target="${existing}" />`,
+            message: markup`Defined already by <filelink target="${existing}" />`,
           },
         ],
       }),
@@ -521,7 +521,7 @@ export const descriptions = createMessages(
           {
             type: 'log',
             category: 'info',
-            message: `Defined already by <filelink emphasis target="${existing}" />`,
+            message: markup`Defined already by <filelink emphasis target="${existing}" />`,
           },
         ],
       }),
@@ -540,7 +540,7 @@ export const descriptions = createMessages(
 
       INCORRECT_CONFIG_FILENAME: (validFilenames: Array<string>) => ({
         category: 'projectManager/incorrectConfigFilename',
-        message: `Invalid rome config filename, <emphasis>${validFilenames.join(
+        message: markup`Invalid rome config filename, <emphasis>${validFilenames.join(
           ' or ',
         )}</emphasis> are the only valid filename`,
       }),
@@ -794,15 +794,16 @@ export const descriptions = createMessages(
                 if (location !== undefined) {
                   if (location.start === undefined) {
                       name =
-                      `<filelink target="${location.filename}">${name}</filelink>`;
+                      markup`<filelink target="${location.filename}">${name}</filelink>`;
                   } else {
                       name =
-                      `<filelink target="${location.filename}" line="${location.start.line}" column="${location.start.column}">${name}</filelink>`;
+                      markup`<filelink target="${location.filename}" line="${location.start.line}" column="${location.start.column}">${name}</filelink>`;
                   }
                 }
 
                 if (source !== undefined) {
-                  name += ` <dim>(from <filelink target="${source}" />)</dim>`;
+                    name +=
+                    markup` <dim>(from <filelink target="${source}" />)</dim>`;
                 }
 
                 return name;

--- a/packages/@romejs/diagnostics/errors.ts
+++ b/packages/@romejs/diagnostics/errors.ts
@@ -6,7 +6,6 @@
  */
 
 import {Diagnostics, DiagnosticsProcessor} from '@romejs/diagnostics';
-import {escapeMarkup, stripAnsi} from '@romejs/string-markup';
 import {printDiagnosticsToString} from '@romejs/cli-diagnostics';
 import {Diagnostic, DiagnosticSuppressions} from './types';
 
@@ -21,12 +20,9 @@ export class DiagnosticsError extends Error {
     }
 
     message += '\n';
-    message += stripAnsi(printDiagnosticsToString({diagnostics, suppressions}));
-    message += stripAnsi(diagnostics.map(
-      (diag) => `- ${diag.description.message.value}`,
-    ).join('\n'));
+    message += printDiagnosticsToString({diagnostics, suppressions});
 
-    super(escapeMarkup(message));
+    super(message);
     this.diagnostics = diagnostics;
     this.suppressions = suppressions;
     this.name = 'DiagnosticsError';

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -286,7 +286,10 @@ function pushComment(parser: JSParser, opts: {
   if (opts.block) {
     comment = {
       type: 'CommentBlock',
-      value: opts.text,
+      // Remove carriage returns. We want to have predictable line endings.
+      // If this is indeed a Windows systems then we'll correctly retain their line endings
+      // in the lint autofixer.
+      value: opts.text.replace(/\r/g, ''),
       loc,
     };
   } else {

--- a/packages/@romejs/parser-core/index.ts
+++ b/packages/@romejs/parser-core/index.ts
@@ -38,6 +38,7 @@ import {
   get0,
   add,
   sub,
+  dec,
 } from '@romejs/ob1';
 import {escapeMarkup} from '@romejs/string-markup';
 import {UnknownFilePath, createUnknownFilePath} from '@romejs/path';
@@ -715,11 +716,14 @@ export function isESIdentifierStart(char: undefined | string): boolean {
   return char !== undefined && /[A-Fa-z_$]/.test(char);
 }
 
-export function isEscaped(index: Number0, input: string) {
+export function isEscaped(index: Number0, input: string): boolean {
   const prevChar = input[get0(index) - 1];
-  const prevPrevChar = input[get0(index) - 2];
-  const isEscaped = prevChar === '\\' && prevPrevChar !== '\\';
-  return isEscaped;
+
+  if (prevChar === '\\') {
+    return !isEscaped(dec(index), input);
+  } else {
+    return false;
+  }
 }
 
 export function readUntilLineBreak(char: string): boolean {

--- a/packages/@romejs/string-markup/escape.test.ts
+++ b/packages/@romejs/string-markup/escape.test.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import test from '@romejs/test';
+import {unescapeTextValue, escapeMarkup} from './escape';
+
+test('should properly escape and then unescape backslashes', (t) => {
+  t.is(unescapeTextValue(escapeMarkup('\\')), '\\');
+  t.is(escapeMarkup('C:\\Users\\sebmck\\'), 'C:\\\\Users\\\\sebmck\\\\');
+});

--- a/packages/@romejs/string-markup/escape.ts
+++ b/packages/@romejs/string-markup/escape.ts
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {coerce0} from '@romejs/ob1';
 import {Dict} from '@romejs/typescript-helpers';
 import {MarkupTagName} from './types';
-import {isEscaped} from '@romejs/parser-core';
 
 // A tagged template literal helper that will escape all interpolated strings, ensuring only markup works
 export function markup(
@@ -47,27 +45,17 @@ export function safeMarkup(input: string): SafeMarkup {
   return new SafeMarkup(input);
 }
 
+// Escape all \ and >
 export function escapeMarkup(input: string): string {
   let escaped = '';
   for (let i = 0; i < input.length; i++) {
     const char = input[i];
-    const isLast = i == input.length - 1;
 
-    // Escape all <
-    if (input[i] === '<') {
-      // If it's escaped then we need to escape the escape
-      // TODO, but what if the escape needs to be escaped......???
-      if (isEscaped(coerce0(i), input)) {
-        escaped += '\\';
-      }
+    if (char === '<') {
       escaped += '\\<';
+    } else if (char === '\\') {
+      escaped += '\\\\';
     } else {
-      // If this is the final character and we're a slash that is not escaped, ignore it.
-      // We could have a tag after the end of this string that would be broken.
-      if (isLast && char === '\\' && !isEscaped(coerce0(i - 1), input)) {
-        continue;
-      }
-
       escaped += char;
     }
   }
@@ -91,4 +79,27 @@ export function markupTag(
   ret += `>${text}</${tagName}>`;
 
   return ret;
+}
+
+export function unescapeTextValue(str: string): string {
+  let unescaped = '';
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    // Unescape \\< to just <
+    // Unescape \\\\ to just \\
+    if (char === '\\') {
+      const nextChar = str[i + 1];
+      if (nextChar === '<' || nextChar === '\\') {
+        i++;
+        unescaped += nextChar;
+        continue;
+      }
+    }
+
+    unescaped += char;
+  }
+
+  return unescaped;
 }

--- a/packages/@romejs/string-markup/parse.test.md
+++ b/packages/@romejs/string-markup/parse.test.md
@@ -4,6 +4,8 @@
 
 ## `should not parse string escapes`
 
+### `0`
+
 ```javascript
 Array [
   Tag {
@@ -16,5 +18,37 @@ Array [
     ]
     children: Array []
   }
+]
+```
+
+### `1`
+
+```javascript
+Array [
+  Tag {
+    name: 'blue'
+    attributes: Map []
+    children: Array [Text {value: '[MemoryFileSystem] Adding new project folder C:\\Users\\sebmck\\rome'}]
+  }
+]
+```
+
+### `2`
+
+```javascript
+Array [
+  Text {value: '  <blue>[MemoryFileSystem] Adding new project folder C:\\Users\\Sebastian\\rome\\</blue>\n        '}
+  Tag {
+    name: 'red'
+    attributes: Map []
+    children: Array [
+      Tag {
+        name: 'emphasis'
+        attributes: Map []
+        children: Array [Text {value: '^'}]
+      }
+    ]
+  }
+  Text {value: ' '}
 ]
 ```

--- a/packages/@romejs/string-markup/parse.test.ts
+++ b/packages/@romejs/string-markup/parse.test.ts
@@ -8,6 +8,20 @@
 import test from '@romejs/test';
 import {parseMarkup} from './parse';
 
-test('should not parse string escapes', (t) => {
-  t.snapshot(parseMarkup('<filelink target="C:\\Users\\sebmck\\file.ts" />'));
-});
+test(
+  'should not parse string escapes',
+  (t) => {
+    t.snapshot(parseMarkup('<filelink target="C:\\Users\\sebmck\\file.ts" />'));
+    t.snapshot(
+      parseMarkup(
+        '<blue>[MemoryFileSystem] Adding new project folder C:\\Users\\sebmck\\rome</blue>',
+      ),
+    );
+
+    t.snapshot(
+      parseMarkup(
+        '  \\<blue>[MemoryFileSystem] Adding new project folder C:\\\\Users\\\\Sebastian\\\\rome\\\\\\</blue>\n        <red><emphasis>^</emphasis></red> ',
+      ),
+    );
+  },
+);

--- a/packages/@romejs/string-markup/parse.ts
+++ b/packages/@romejs/string-markup/parse.ts
@@ -23,6 +23,7 @@ import {
 } from './types';
 import {inc, Number0, add, get0} from '@romejs/ob1';
 import {descriptions} from '@romejs/diagnostics';
+import {unescapeTextValue} from './escape';
 
 const globalAttributes: Array<string> = ['emphasis', 'dim'];
 
@@ -351,25 +352,4 @@ export function parseMarkup(input: string) {
   } catch (err) {
     throw err;
   }
-}
-
-function unescapeTextValue(str: string): string {
-  let unescaped = '';
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i];
-
-    if (char === '\\') {
-      const nextChar = str[i + 1];
-      if (nextChar === '<') {
-        i++;
-        unescaped += '<';
-        continue;
-      }
-    }
-
-    unescaped += char;
-  }
-
-  return unescaped;
 }


### PR DESCRIPTION
- Carriage returns in line endings are preserved when autoformatting. Sometimes Git repos on Windows will have `\r\n` newlines. When we check if a file has pending fixes, we would previously show every single `\r` being removed. We now retain it if the source file had it.
- Always escape `\\`. This required going through all the places where we interpolate values into a markup string with our `markup` tagged template to ensure that everything is properly escaped. There are likely callsites I missed.
- Fix `isEscaped` to check if the escaped escape is not escaped...
- Use unicode character alternatives for log category prefixes when under Windows that has horrid support in `cmd.exe`.