### PR TITLE
Add support for manifest exports fallback arrays

### DIFF
--- a/packages/@romejs/cli-flags/Parser.ts
+++ b/packages/@romejs/cli-flags/Parser.ts
@@ -339,7 +339,7 @@ export default class Parser<T> {
 
     let definedCommand: undefined | DefinedCommand;
 
-    const rootFlags = await consumer.captureDiagnostics(async (consumer) => {
+    const rootFlags = await consumer.bufferDiagnostics(async (consumer) => {
       for (const shorthandName of this.shorthandFlags) {
         consumer.get(shorthandName).unexpected(
           `Shorthand flags are not supported`,
@@ -519,18 +519,16 @@ export default class Parser<T> {
 
     const {description, usage, examples, programName} = this.opts;
 
-    const consumer = this.getFlagsConsumer();
+    const {consumer} = this.getFlagsConsumer().capture();
 
     // Supress diagnostics
-    await consumer.capture(async (consumer) => {
-      await this.opts.defineFlags(consumer);
+    await this.opts.defineFlags(consumer);
 
-      for (const key of this.commands.keys()) {
-        await this.defineCommandFlags(key, consumer);
-      }
+    for (const key of this.commands.keys()) {
+      await this.defineCommandFlags(key, consumer);
+    }
 
-      this.showUsageHelp(description, usage);
-    });
+    this.showUsageHelp(description, usage);
 
     const {reporter} = this;
     reporter.section('Global Flags', () => {

--- a/packages/@romejs/codec-js-manifest/convert.ts
+++ b/packages/@romejs/codec-js-manifest/convert.ts
@@ -32,7 +32,11 @@ export function convertManifestToJSON(manifest: Manifest): JSONManifest {
     bugs: manifest.bugs,
 
     main: manifest.main,
-    exports: exportsToObject(manifest.exports),
+
+    // TODO we now support fallbacks which means manifest.exports is lossy
+    //exports: exportsToObject(manifest.exports),
+    // rome-suppress-next-line lint/noExplicitAny
+    exports: (manifest.raw.exports as any),
 
     author: manifest.author,
     contributors: manifest.contributors,
@@ -102,6 +106,7 @@ function exportsToObject(
 
   return obj;
 }
+exportsToObject;
 
 function maybeArray<T>(items: Array<T>): undefined | Array<T> {
   if (items.length === 0) {

--- a/packages/@romejs/codec-js-manifest/index.ts
+++ b/packages/@romejs/codec-js-manifest/index.ts
@@ -463,9 +463,8 @@ function normalizeExportsConditions(value: Consumer): ManifestExportConditions {
   } else if (Array.isArray(unknown)) {
     // Find the first item that passes validation
     for (const elem of value.asArray()) {
-      const {result, diagnostics} = elem.captureSync(
-        (consumer) => normalizeExportsConditions(consumer),
-      );
+      const {consumer, diagnostics} = elem.capture();
+      const result = normalizeExportsConditions(consumer);
       if (diagnostics.length === 0) {
         return result;
       }
@@ -581,96 +580,84 @@ function checkDependencyKeyTypo(key: string, prop: Consumer) {
 
 export async function normalizeManifest(
   path: AbsoluteFilePath,
-  consumer: Consumer,
+  rawConsumer: Consumer,
 ): Promise<{
   manifest: Manifest;
   diagnostics: Diagnostics;
 }> {
   const loose = path.getSegments().includes('node_modules');
 
-  const {result: manifest, diagnostics} = await consumer.capture(
-    (consumer) => {
-      // FIXME: There's this ridiculous node module that includes it's tests... which deliberately includes an invalid package.json
-      if (path.join().includes('resolve/test/resolver/invalid_main')) {
-        consumer.setValue({});
+  const {consumer, diagnostics} = rawConsumer.capture();
+
+  // FIXME: There's this ridiculous node module that includes it's tests... which deliberately includes an invalid package.json
+  if (path.join().includes('resolve/test/resolver/invalid_main')) {
+    consumer.setValue({});
+  }
+
+  //
+  if (!loose) {
+    for (const [key, prop] of consumer.asMap()) {
+      // Check for typos for dependencies
+      checkDependencyKeyTypo(key, prop);
+
+      // Check for other typos
+      const correctKey = TYPO_KEYS.get(key);
+      if (correctKey !== undefined) {
+        prop.unexpected(`${key} is a typo of ${correctKey}`);
       }
+    }
+  }
 
-      //
-      if (!loose) {
-        for (const [key, prop] of consumer.asMap()) {
-          // Check for typos for dependencies
-          checkDependencyKeyTypo(key, prop);
+  const name = normalizeRootName(consumer, loose);
 
-          // Check for other typos
-          const correctKey = TYPO_KEYS.get(key);
-          if (correctKey !== undefined) {
-            prop.unexpected(`${key} is a typo of ${correctKey}`);
-          }
-        }
-      }
+  const manifest: Manifest = {
+    name,
+    version: normalizeVersion(consumer, loose),
+    private: normalizeBoolean(consumer, 'private') === true,
+    description: normalizeString(consumer, 'description'),
+    license: normalizeLicense(consumer, loose),
+    type: consumer.get('type').asStringSetOrVoid(['module', 'commonjs']),
 
-      const name = normalizeRootName(consumer, loose);
+    bin: normalizeBin(consumer, name, loose),
+    scripts: normalizeStringMap(consumer, 'scripts', loose),
+    homepage: normalizeString(consumer, 'homepage'),
+    repository: normalizeRepo(consumer.get('repository'), loose),
+    bugs: normalizeBugs(consumer.get('bugs'), loose),
+    engines: normalizeStringMap(consumer, 'engines', loose),
 
-      const manifest: Manifest = {
-        name,
-        version: normalizeVersion(consumer, loose),
-        private: normalizeBoolean(consumer, 'private') === true,
-        description: normalizeString(consumer, 'description'),
-        license: normalizeLicense(consumer, loose),
-        type: consumer.get('type').asStringSetOrVoid(['module', 'commonjs']),
+    files: normalizePathPatterns(consumer.get('files'), loose),
+    keywords: normalizeStringArray(consumer.get('keywords'), loose),
+    cpu: normalizeStringArray(consumer.get('cpu'), loose),
+    os: normalizeStringArray(consumer.get('os'), loose),
 
-        bin: normalizeBin(consumer, name, loose),
-        scripts: normalizeStringMap(consumer, 'scripts', loose),
-        homepage: normalizeString(consumer, 'homepage'),
-        repository: normalizeRepo(consumer.get('repository'), loose),
-        bugs: normalizeBugs(consumer.get('bugs'), loose),
-        engines: normalizeStringMap(consumer, 'engines', loose),
+    main: normalizeString(consumer, 'main'),
+    exports: normalizeExports(consumer.get('exports')),
 
-        files: normalizePathPatterns(consumer.get('files'), loose),
-        keywords: normalizeStringArray(consumer.get('keywords'), loose),
-        cpu: normalizeStringArray(consumer.get('cpu'), loose),
-        os: normalizeStringArray(consumer.get('os'), loose),
+    // Dependency fields
+    dependencies: normalizeDependencies(consumer, 'dependencies', loose),
+    devDependencies: normalizeDependencies(consumer, 'devDependencies', loose),
+    optionalDependencies: normalizeDependencies(
+      consumer,
+      'optionalDependencies',
+      loose,
+    ),
+    peerDependencies: normalizeDependencies(consumer, 'peerDependencies', loose),
+    bundledDependencies: [
+      ...normalizeStringArray(consumer.get('bundledDependencies'), loose),
 
-        main: normalizeString(consumer, 'main'),
-        exports: normalizeExports(consumer.get('exports')),
+      // Common misspelling. We error on the existence of this for strict manifests already.
+      ...normalizeStringArray(consumer.get('bundleDependencies'), loose),
+    ],
 
-        // Dependency fields
-        dependencies: normalizeDependencies(consumer, 'dependencies', loose),
-        devDependencies: normalizeDependencies(
-          consumer,
-          'devDependencies',
-          loose,
-        ),
-        optionalDependencies: normalizeDependencies(
-          consumer,
-          'optionalDependencies',
-          loose,
-        ),
-        peerDependencies: normalizeDependencies(
-          consumer,
-          'peerDependencies',
-          loose,
-        ),
-        bundledDependencies: [
-          ...normalizeStringArray(consumer.get('bundledDependencies'), loose),
+    // People fields
+    author: consumer.has('author')
+      ? normalizePerson(consumer.get('author'), loose)
+      : undefined,
+    contributors: normalizePeople(consumer.get('contributors'), loose),
+    maintainers: normalizePeople(consumer.get('maintainers'), loose),
 
-          // Common misspelling. We error on the existence of this for strict manifests already.
-          ...normalizeStringArray(consumer.get('bundleDependencies'), loose),
-        ],
-
-        // People fields
-        author: consumer.has('author')
-          ? normalizePerson(consumer.get('author'), loose)
-          : undefined,
-        contributors: normalizePeople(consumer.get('contributors'), loose),
-        maintainers: normalizePeople(consumer.get('maintainers'), loose),
-
-        raw: consumer.asJSONObject(),
-      };
-
-      return manifest;
-    },
-  );
+    raw: consumer.asJSONObject(),
+  };
 
   return {
     manifest,

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -133,27 +133,7 @@ export default class Consumer {
   hasHandledUnexpected: boolean;
   forceDiagnosticTarget: undefined | ConsumeSourceLocationRequestTarget;
 
-  async capture<T>(callback: (consumer: Consumer) => Promise<T> | T): Promise<{
-    result: T;
-    definitions: Array<ConsumePropertyDefinition>;
-    diagnostics: Diagnostics;
-  }> {
-    const {definitions, diagnostics, consumer} = this._capture();
-    const result = await callback(consumer);
-    return {result, definitions, diagnostics};
-  }
-
-  captureSync<T>(callback: (consumer: Consumer) => T): {
-    result: T;
-    definitions: Array<ConsumePropertyDefinition>;
-    diagnostics: Diagnostics;
-  } {
-    const {definitions, diagnostics, consumer} = this._capture();
-    const result = callback(consumer);
-    return {result, definitions, diagnostics};
-  }
-
-  _capture<T>(): {
+  capture<T>(): {
     consumer: Consumer;
     definitions: Array<ConsumePropertyDefinition>;
     diagnostics: Diagnostics;
@@ -177,10 +157,11 @@ export default class Consumer {
     return {consumer, definitions, diagnostics};
   }
 
-  async captureDiagnostics<T>(
+  async bufferDiagnostics<T>(
     callback: (consumer: Consumer) => Promise<T> | T,
   ): Promise<T> {
-    const {result, diagnostics} = await this.capture(callback);
+    const {diagnostics, consumer} = await this.capture();
+    const result = await callback(consumer);
     if (result === undefined || diagnostics.length > 0) {
       throw new DiagnosticsError('Captured diagnostics', diagnostics);
     }

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -138,6 +138,26 @@ export default class Consumer {
     definitions: Array<ConsumePropertyDefinition>;
     diagnostics: Diagnostics;
   }> {
+    const {definitions, diagnostics, consumer} = this._capture();
+    const result = await callback(consumer);
+    return {result, definitions, diagnostics};
+  }
+
+  captureSync<T>(callback: (consumer: Consumer) => T): {
+    result: T;
+    definitions: Array<ConsumePropertyDefinition>;
+    diagnostics: Diagnostics;
+  } {
+    const {definitions, diagnostics, consumer} = this._capture();
+    const result = callback(consumer);
+    return {result, definitions, diagnostics};
+  }
+
+  _capture<T>(): {
+    consumer: Consumer;
+    definitions: Array<ConsumePropertyDefinition>;
+    diagnostics: Diagnostics;
+  } {
     let diagnostics: Diagnostics = [];
     const definitions: Array<ConsumePropertyDefinition> = [];
 
@@ -154,9 +174,7 @@ export default class Consumer {
         diagnostics.push(diag);
       },
     });
-
-    const result = await callback(consumer);
-    return {result, definitions, diagnostics};
+    return {consumer, definitions, diagnostics};
   }
 
   async captureDiagnostics<T>(
@@ -986,11 +1004,7 @@ export default class Consumer {
     return this._asNumber(def);
   }
 
-  asNumberInRange(opts: {
-    min?: number;
-    max?: number;
-    default?: number;
-  }): number
+  asNumberInRange(opts: {min?: number; max?: number; default?: number}): number
 
   asNumberInRange(opts: {
     min: Number0;


### PR DESCRIPTION
This PR adds support for fallback exports arrays to our manifest validation.

This was tricky as it required catching diagnostics when validating each element, and returning the first valid one.

Possible improvements:

- Adding in lossless serialization, since we lose all the intermediate fallbacks
- What do we do if none of them are valid?

Documentation:

- https://github.com/jkrems/proposal-pkg-exports#validations-and-fallbacks
- https://nodejs.org/api/esm.html#esm_package_exports_fallbacks