### PR TITLE
fix sourcemaps generation

### DIFF
--- a/packages/@romejs/js-compiler/api/compile.ts
+++ b/packages/@romejs/js-compiler/api/compile.ts
@@ -44,6 +44,7 @@ export default async function compile(
   const generator = formatJS(transformedAst, {
     typeAnnotations: false,
     indent: req.stage === 'compileForBundle' ? 1 : 0,
+    format: 'pretty',
     sourceMapTarget: filename,
     sourceFileName: filename,
     inputSourceMap: req.inputSourceMap,

--- a/packages/@romejs/js-compiler/api/compile.ts
+++ b/packages/@romejs/js-compiler/api/compile.ts
@@ -44,7 +44,6 @@ export default async function compile(
   const generator = formatJS(transformedAst, {
     typeAnnotations: false,
     indent: req.stage === 'compileForBundle' ? 1 : 0,
-    format: 'pretty',
     sourceMapTarget: filename,
     sourceFileName: filename,
     inputSourceMap: req.inputSourceMap,

--- a/packages/@romejs/js-formatter/Printer.ts
+++ b/packages/@romejs/js-formatter/Printer.ts
@@ -210,23 +210,26 @@ export default class Printer {
       str = this.state.indentString + str;
     }
 
-    // Determine if we need to line wrap. We skip this when we aren't in pretty mode for better performance.
-    if (this.lineWrap) {
-      const {lastUnbrokenGroup} = this;
+    const {lastUnbrokenGroup} = this;
 
-      for (const char of str) {
-        if (char === '\n') {
+    for (const char of str) {
+      if (char === '\n') {
+        // Determine if we need to line wrap. We skip this when we aren't in pretty mode for better performance.
+        if (this.lineWrap) {
           if (lastUnbrokenGroup !== undefined &&
               lastUnbrokenGroup.breakOnNewline) {
             throw new BreakGroupError(lastUnbrokenGroup);
           }
-          this.state.generatedColumn = number0;
-          this.state.generatedLine = inc(this.state.generatedLine);
-        } else {
-          this.state.generatedColumn = inc(this.state.generatedColumn);
         }
+        this.state.generatedColumn = number0;
+        this.state.generatedLine = inc(this.state.generatedLine);
+      } else {
+        this.state.generatedColumn = inc(this.state.generatedColumn);
       }
+    }
 
+    // Determine if we need to line wrap. We skip this when we aren't in pretty mode for better performance.
+    if (this.lineWrap) {
       if (lastUnbrokenGroup !== undefined && get0(this.state.generatedColumn) >
           MAX_LINE_LENGTH) {
         throw new BreakGroupError(lastUnbrokenGroup);


### PR DESCRIPTION
This fixes source maps generation which was also prevent --coverage option to work 
![image](https://user-images.githubusercontent.com/5262527/79183259-f97aae80-7dde-11ea-8c7e-035bef1d5d00.png)

This was the easiest fix, but I wasn't sure if it was the right one. I also considered refactoring 
https://github.com/facebookexperimental/rome/blob/d95a3a7aab90773c9b36d9c82a08c8c4c6b68aa5/packages/%40romejs/js-formatter/Printer.ts#L214-L234
to increment `generatedColumn` even if `lineWrap` is false, but wasn't sure. 

Let me know what you think 