### PR TITLE
Fix caching and add bundle compile lock

### DIFF
--- a/packages/@romejs/core/master/Cache.ts
+++ b/packages/@romejs/core/master/Cache.ts
@@ -114,7 +114,7 @@ export default class Cache {
     // If we have a loaded memory entry, make sure it's valid compared to the default entry (file changes etc)
     let loaded = this.loadedEntries.get(path);
     if (loaded !== undefined && areEntriesEqual(loaded, emptyEntry)) {
-      return emptyEntry;
+      return loaded;
     }
 
     if (this.disabled) {

--- a/packages/@romejs/core/master/bundler/BundleRequest.ts
+++ b/packages/@romejs/core/master/bundler/BundleRequest.ts
@@ -183,6 +183,8 @@ export default class BundleRequest {
       assetPath,
     };
 
+    const lock = await this.bundler.compileLocker.getLock(source);
+
     const res: WorkerCompileResult = await this.bundler.request.requestWorkerCompile(
       path,
       'compileForBundle',
@@ -191,6 +193,8 @@ export default class BundleRequest {
       },
       {},
     );
+
+    lock.release();
 
     if (!res.cached) {
       this.cached = false;

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -28,6 +28,7 @@ import {Dict} from '@romejs/typescript-helpers';
 import {readFile} from '@romejs/fs';
 import {flipPathPatterns} from '@romejs/path-match';
 import {markup} from '@romejs/string-markup';
+import Locker from '@romejs/core/common/utils/Locker';
 
 export type BundlerEntryResoluton = {
   manifestDef: undefined | ManifestDefinition;
@@ -43,9 +44,11 @@ export default class Bundler {
 
     this.entries = [];
 
+    this.compileLocker = new Locker();
     this.graph = new DependencyGraph(req, config.resolver);
   }
 
+  compileLocker: Locker<string>;
   graph: DependencyGraph;
   master: Master;
   request: MasterRequest;


### PR DESCRIPTION
Turns out our in-memory caching in the master was broken. This basically meant when we were bundling test files we were compiling every single file, which is why it was so slow.

While weren't hitting the master cache, we were hitting the worker memory cache. We still incurred considerable overhead marshalling this data back and forth, especially with the size of the individual file mappings array, which is huge. We should also look into minimizing the size of it.

I also noticed that there could be race conditions since we sometimes bundle files in parallel, meaning we could be compiling multiple times at one point in time, so I added a lock so we wait, and hopefully hit the cache when the lock is released.