### PR TITLE
Improve multiple bundle performance even more

### DIFF
--- a/packages/@romejs/cli-reporter/Progress.ts
+++ b/packages/@romejs/cli-reporter/Progress.ts
@@ -297,7 +297,7 @@ export default class Progress extends ProgressBase {
   }
 
   buildBar(stream: ReporterStream) {
-    const {total, current, text, title} = this;
+    const {total, current, title} = this;
 
     // Text ranges that we should make bold
     const boldRanges: BoldRanges = [];
@@ -310,6 +310,8 @@ export default class Progress extends ProgressBase {
       // Only the title should be bold, not the subtext
       boldRanges.push([0, prefix.length - 1]);
     }
+
+    const text = this.getText();
     if (text !== undefined) {
       // Separate a title and it's text with a colon
       if (title !== undefined) {

--- a/packages/@romejs/cli-reporter/ProgressBase.ts
+++ b/packages/@romejs/cli-reporter/ProgressBase.ts
@@ -70,8 +70,17 @@ export default class ProgressBase implements ReporterProgress {
     }
   }
 
+  getText(): undefined | string {
+    const {text} = this;
+    if (text === undefined) {
+      return undefined;
+    } else {
+      return this.reporter.stripMarkup(text);
+    }
+  }
+
   setText(text: string) {
-    this.text = this.reporter.stripMarkup(text);
+    this.text = text;
     this.queueRender();
   }
 

--- a/packages/@romejs/cli/bin/rome.ts
+++ b/packages/@romejs/cli/bin/rome.ts
@@ -15,6 +15,7 @@ import master from '../master';
 import testWorker from '../testWorker';
 import worker from '../worker';
 import {readFileTextSync} from '@romejs/fs';
+import {SourceMapConsumer} from '@romejs/codec-source-map';
 
 async function main() {
   switch (process.env.ROME_PROCESS_VERSION === VERSION &&
@@ -34,8 +35,8 @@ async function main() {
 }
 
 sourceMapManager.init();
-sourceMapManager.addSourceMapFactory(BIN.join(), () => JSON.parse(
-  readFileTextSync(MAP),
+sourceMapManager.addSourceMap(BIN.join(), () => SourceMapConsumer.fromJSON(
+  JSON.parse(readFileTextSync(MAP)),
 ));
 
 main().catch((err) => {

--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -103,6 +103,9 @@ export default async function cli() {
             collectMarkers: c.get('collectMarkers').asBoolean(
               DEFAULT_CLIENT_REQUEST_FLAGS.collectMarkers,
             ),
+            timing: c.get('timing').asBoolean(
+              DEFAULT_CLIENT_REQUEST_FLAGS.timing,
+            ),
             watch: c.get('watch').asBoolean(DEFAULT_CLIENT_REQUEST_FLAGS.watch),
             fieri: c.get('fieri').asBoolean(DEFAULT_CLIENT_REQUEST_FLAGS.fieri),
             focus: c.get('focus').asString(DEFAULT_CLIENT_REQUEST_FLAGS.focus),

--- a/packages/@romejs/codec-source-map/SourceMapConsumer.ts
+++ b/packages/@romejs/codec-source-map/SourceMapConsumer.ts
@@ -7,9 +7,9 @@
 
 import {
   SourceMap,
+  ResolvedLocation,
   ParsedMapping,
   ParsedMappings,
-  ResolvedLocation,
 } from './types';
 import {decodeVLQ} from './base64';
 import {
@@ -24,22 +24,33 @@ import {
 } from '@romejs/ob1';
 import {Dict} from '@romejs/typescript-helpers';
 
-function getCacheKey(line: Number1, column: Number0): string {
+export function getParsedMappingKey(line: Number1, column: Number0): string {
   return `${String(line)}:${String(column)}`;
 }
 
+type GetMappings = () => ParsedMappings;
+
 export default class SourceMapConsumer {
-  constructor(map: SourceMap) {
-    this.map = map;
+  constructor(file: string, getMappings: GetMappings) {
+    this.file = file;
+    this._getMappings = getMappings;
     this.mappings = undefined;
   }
 
-  map: SourceMap;
+  file: string;
+  _getMappings: GetMappings;
   mappings: undefined | ParsedMappings;
 
   static charIsMappingSeparator(str: string, index: number): boolean {
     const c = str.charAt(index);
     return c === ';' || c === ',';
+  }
+
+  static fromJSON(sourceMap: SourceMap): SourceMapConsumer {
+    return new SourceMapConsumer(
+      sourceMap.file,
+      () => SourceMapConsumer.parseMappings(sourceMap),
+    );
   }
 
   static parseMappings(sourceMap: SourceMap): ParsedMappings {
@@ -67,11 +78,15 @@ export default class SourceMapConsumer {
         index++;
       } else {
         const mapping: ParsedMapping = {
-          generatedLine,
-          generatedColumn: number0,
+          generated: {
+            line: generatedLine,
+            column: number0,
+          },
+          original: {
+            line: number1,
+            column: number0,
+          },
           source: undefined,
-          originalLine: number1,
-          originalColumn: number0,
           name: undefined,
         };
 
@@ -110,12 +125,12 @@ export default class SourceMapConsumer {
         }
 
         // Generated column
-        mapping.generatedColumn = add(previousGeneratedColumn, segment[0]);
-        previousGeneratedColumn = mapping.generatedColumn;
+        mapping.generated.column = add(previousGeneratedColumn, segment[0]);
+        previousGeneratedColumn = mapping.generated.column;
 
         if (segment.length > 1) {
           // Original source
-          mapping.source = previousSource + segment[1];
+          mapping.source = sourceMap.sources[previousSource + segment[1]];
           previousSource += segment[1];
 
           // Original line
@@ -123,24 +138,24 @@ export default class SourceMapConsumer {
           previousOriginalLine = newOriginalLine;
 
           // Lines are stored 0-based
-          mapping.originalLine = add(newOriginalLine, 1);
+          mapping.original.line = add(newOriginalLine, 1);
 
           // Original column
           const newOriginalColumn = add(previousOriginalColumn, segment[3]);
-          mapping.originalColumn = newOriginalColumn;
+          mapping.original.column = newOriginalColumn;
           previousOriginalColumn = newOriginalColumn;
 
           if (segment.length > 4) {
             // Original name
-            mapping.name = previousName + segment[4];
+            mapping.name = sourceMap.names[previousName + segment[4]];
             previousName += segment[4];
           }
         }
 
-        map.set(
-          getCacheKey(mapping.generatedLine, mapping.generatedColumn),
-          mapping,
-        );
+        map.set(getParsedMappingKey(
+          mapping.generated.line,
+          mapping.generated.column,
+        ), mapping);
       }
     }
 
@@ -149,7 +164,7 @@ export default class SourceMapConsumer {
 
   getMappings(): ParsedMappings {
     if (this.mappings === undefined) {
-      const mappings = SourceMapConsumer.parseMappings(this.map);
+      const mappings = this._getMappings();
       this.mappings = mappings;
       return mappings;
     } else {
@@ -178,26 +193,22 @@ export default class SourceMapConsumer {
     line: Number1,
     column: Number0,
   ): undefined | ResolvedLocation {
-    const key = getCacheKey(line, column);
+    const key = getParsedMappingKey(line, column);
     const mapping = this.getMappings().get(key);
     if (mapping === undefined) {
       return undefined;
     }
 
-    const source = mapping.source === undefined
-      ? this.map.file
-      : this.map.sources[mapping.source];
+    const source = mapping.source === undefined ? this.file : mapping.source;
     if (source === undefined) {
       throw new Error('Mapping provided unknown source');
     }
 
     return {
       source,
-      line: mapping.originalLine,
-      column: mapping.originalColumn,
-      name: mapping.name === undefined
-        ? undefined
-        : this.map.names[mapping.name],
+      line: mapping.original.line,
+      column: mapping.original.column,
+      name: mapping.name,
     };
   }
 }

--- a/packages/@romejs/codec-source-map/SourceMapConsumerCollection.ts
+++ b/packages/@romejs/codec-source-map/SourceMapConsumerCollection.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SourceMapConsumer from './SourceMapConsumer';
+import {Number1, Number0} from '@romejs/ob1';
+import {ResolvedLocation} from './types';
+import {DiagnosticLocation} from '@romejs/diagnostics';
+
+export default class SourceMapConsumerCollection {
+  constructor() {
+    this.maps = new Map();
+  }
+
+  maps: Map<string, SourceMapConsumer>;
+
+  hasAny(): boolean {
+    return this.maps.size > 0;
+  }
+
+  has(file: string): boolean {
+    return this.maps.has(file);
+  }
+
+  add(file: string, map: SourceMapConsumer) {
+    this.maps.set(file, map);
+  }
+
+  get(file: string): undefined | SourceMapConsumer {
+    return this.maps.get(file);
+  }
+
+  resolveLocation(location: DiagnosticLocation): DiagnosticLocation {
+    let {filename, start, end} = location;
+    if (filename === undefined) {
+      return location;
+    }
+
+    if (start !== undefined) {
+      const resolved = this.exactOriginalPositionFor(
+        filename,
+        start.line,
+        start.column,
+      );
+      if (resolved !== undefined) {
+        filename = resolved.source;
+        start = {
+          ...start,
+          line: resolved.line,
+          column: resolved.column,
+        };
+      }
+    }
+
+    if (end !== undefined) {
+      const resolved = this.exactOriginalPositionFor(
+        filename,
+        end.line,
+        end.column,
+      );
+      if (resolved !== undefined) {
+        // TODO confirm this is the same as `start` if it resolved
+        filename = resolved.source;
+        end = {
+          ...end,
+          line: resolved.line,
+          column: resolved.column,
+        };
+      }
+    }
+
+    return {...location, filename, start, end};
+  }
+
+  approxOriginalPositionFor(
+    file: string,
+    line: Number1,
+    column: Number0,
+  ): undefined | ResolvedLocation {
+    const map = this.get(file);
+    if (map === undefined) {
+      return undefined;
+    } else {
+      return map.approxOriginalPositionFor(line, column);
+    }
+  }
+
+  exactOriginalPositionFor(
+    file: string,
+    line: Number1,
+    column: Number0,
+  ): undefined | ResolvedLocation {
+    const map = this.get(file);
+    if (map === undefined) {
+      return undefined;
+    } else {
+      return map.exactOriginalPositionFor(line, column);
+    }
+  }
+}

--- a/packages/@romejs/codec-source-map/SourceMapConsumerCollection.ts
+++ b/packages/@romejs/codec-source-map/SourceMapConsumerCollection.ts
@@ -40,7 +40,7 @@ export default class SourceMapConsumerCollection {
     }
 
     if (start !== undefined) {
-      const resolved = this.exactOriginalPositionFor(
+      const resolved = this.approxOriginalPositionFor(
         filename,
         start.line,
         start.column,
@@ -56,7 +56,7 @@ export default class SourceMapConsumerCollection {
     }
 
     if (end !== undefined) {
-      const resolved = this.exactOriginalPositionFor(
+      const resolved = this.approxOriginalPositionFor(
         filename,
         end.line,
         end.column,

--- a/packages/@romejs/codec-source-map/SourceMapGenerator.ts
+++ b/packages/@romejs/codec-source-map/SourceMapGenerator.ts
@@ -11,15 +11,18 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-import {Mapping, SourceMap} from './types';
+import {Mapping, SourceMap, Mappings, ParsedMappings} from './types';
 import * as base64 from './base64';
 import {compareByGeneratedPositionsInflated, toRelativeUrl} from './util';
 import ArraySet from './ArraySet';
 import MappingList from './MappingList';
 import {Number1, Number0, get1, get0, number0, number1, inc} from '@romejs/ob1';
+import SourceMapConsumer, {getParsedMappingKey} from './SourceMapConsumer';
+
+type MaterializeCallback = () => void;
 
 export default class SourceMapGenerator {
-  constructor(args: {file?: string; sourceRoot?: string}) {
+  constructor(args: {file: string; sourceRoot?: string}) {
     this.file = args.file;
     this.sourceRoot = args.sourceRoot;
 
@@ -28,9 +31,11 @@ export default class SourceMapGenerator {
     this.sources = new ArraySet();
     this.names = new ArraySet();
     this.mappings = new MappingList();
+    this.materializeCallbacks = [];
   }
 
-  file: undefined | string;
+  file: string;
+  materializeCallbacks: Array<MaterializeCallback>;
   sourceRoot: undefined | string;
   sources: ArraySet;
   names: ArraySet;
@@ -41,9 +46,13 @@ export default class SourceMapGenerator {
   assertUnlocked() {
     if (this.map !== undefined) {
       throw new Error(
-          'Source map has already been materialized, toJSON() should be your final call',
+          'Source map has already been materialized, serialize() should be your final call',
         );
     }
+  }
+
+  addMaterializer(fn: MaterializeCallback) {
+    this.materializeCallbacks.push(fn);
   }
 
   /**
@@ -200,13 +209,22 @@ export default class SourceMapGenerator {
     });
   }
 
+  materialize() {
+    for (const fn of this.materializeCallbacks) {
+      fn();
+    }
+    this.materializeCallbacks = [];
+  }
+
   /**
    * Externalize the source map.
    */
-  toJSON(): SourceMap {
+  serialize(): SourceMap {
     if (this.map !== undefined) {
       return this.map;
     }
+
+    this.materialize();
 
     const sources = this.sources.toArray();
     this.map = {
@@ -222,16 +240,33 @@ export default class SourceMapGenerator {
   }
 
   toComment(): string {
-    const jsonMap = this.toString();
+    const jsonMap = this.toJSON();
     const base64Map = new Buffer(jsonMap).toString('base64');
     const comment = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Map}`;
     return comment;
   }
 
-  /**
-   * Render the source map being generated to a string.
-   */
-  toString(): string {
-    return JSON.stringify(this.toJSON());
+  toConsumer(): SourceMapConsumer {
+    return new SourceMapConsumer(this.file, () => {
+      const parsedMappings: ParsedMappings = new Map();
+
+      for (const mapping of this.getMappings()) {
+        parsedMappings.set(getParsedMappingKey(
+          mapping.generated.line,
+          mapping.generated.column,
+        ), mapping);
+      }
+
+      return parsedMappings;
+    });
+  }
+
+  getMappings(): Mappings {
+    this.materialize();
+    return this.mappings.toArray();
+  }
+
+  toJSON(): string {
+    return JSON.stringify(this.serialize());
   }
 }

--- a/packages/@romejs/codec-source-map/index.ts
+++ b/packages/@romejs/codec-source-map/index.ts
@@ -7,4 +7,7 @@
 
 export {default as SourceMapGenerator} from './SourceMapGenerator';
 export {default as SourceMapConsumer} from './SourceMapConsumer';
+export {
+  default as SourceMapConsumerCollection,
+} from './SourceMapConsumerCollection';
 export {SourceMap, Mapping, Mappings} from './types';

--- a/packages/@romejs/codec-source-map/types.ts
+++ b/packages/@romejs/codec-source-map/types.ts
@@ -9,13 +9,12 @@ import {Number1, Number0} from '@romejs/ob1';
 
 export type Mappings = Array<Mapping>;
 
-export type Mapping = {
+export type ParsedMapping = {
   generated: {
-    index: Number0;
     line: Number1;
     column: Number0;
   };
-  original: undefined | {
+  original: {
     line: Number1;
     column: Number0;
   };
@@ -23,16 +22,13 @@ export type Mapping = {
   name: undefined | string;
 };
 
-export type ParsedMapping = {
-  generatedLine: Number1;
-  generatedColumn: Number0;
-  originalLine: Number1;
-  originalColumn: Number0;
-  source?: number;
-  name?: number;
+export type Mapping = Omit<ParsedMapping, 'generated'> & {
+  generated: ParsedMapping['generated'] & {
+    index: Number0;
+  };
 };
 
-export type ParsedMappings = Map<string, ParsedMapping>;
+export type ParsedMappings = Map<string, Mapping | ParsedMapping>;
 
 export type ResolvedLocation = {
   source: string;
@@ -48,7 +44,7 @@ export type SourceMapGeneratorOptions = {
 
 export type SourceMap = {
   version: number;
-  file: undefined | string;
+  file: string;
   names: Array<string>;
   mappings: string;
   sourceRoot: undefined | string;

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -14,6 +14,7 @@ import {createAbsoluteFilePath} from '@romejs/path';
 import {Dict} from '@romejs/typescript-helpers';
 import {writeFile, exists} from '@romejs/fs';
 import {VERSION} from '../common/constants';
+import {SourceMapConsumer} from '@romejs/codec-source-map';
 
 // rome-suppress-next-line lint/noExplicitAny
 export const localCommands: Map<string, LocalCommand<any>> = new Map();
@@ -200,7 +201,7 @@ localCommands.set('run', {
           const {syntaxError} = await executeMain({
             path: createAbsoluteFilePath(data.get('filename').asString()),
             code: data.get('code').asString(),
-            sourceMap: data.get('map').asAny(),
+            sourceMap: SourceMapConsumer.fromJSON(data.get('map').asAny()),
           });
           if (syntaxError !== undefined) {
             throw createSingleDiagnosticError(syntaxError);

--- a/packages/@romejs/core/common/bridges/TestWorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/TestWorkerBridge.ts
@@ -6,7 +6,6 @@
  */
 
 import {Diagnostic} from '@romejs/diagnostics';
-import {SourceMap} from '@romejs/codec-source-map';
 import {TestRunnerOptions} from '../../master/testing/types';
 import {Bridge} from '@romejs/events';
 import {JSONFileReference} from '../types/files';
@@ -22,7 +21,6 @@ export type TestWorkerBridgeRunOptions = {
   projectFolder: string;
   code: string;
   cwd: string;
-  sourceMap: SourceMap;
   options: TestRunnerOptions;
 };
 

--- a/packages/@romejs/core/common/types/bundler.ts
+++ b/packages/@romejs/core/common/types/bundler.ts
@@ -6,7 +6,7 @@
  */
 
 import {Diagnostics} from '@romejs/diagnostics';
-import {SourceMap} from '@romejs/codec-source-map';
+import {SourceMapGenerator} from '@romejs/codec-source-map';
 import {AbsoluteFilePath} from '@romejs/path';
 import {ResolverOptions} from '../../master/fs/Resolver';
 
@@ -24,7 +24,7 @@ export type BundleRequestResult = {
   cached: boolean;
   diagnostics: Diagnostics;
   content: string;
-  map: SourceMap;
+  sourceMap: SourceMapGenerator;
   assets: Map<string, Buffer>;
 };
 
@@ -37,14 +37,13 @@ export type BundleBuddyGraphNode = {
 
 export type BundlerFiles = Map<string, {
   kind: 'asset' | 'entry' | 'sourcemap' | 'stats' | 'manifest' | 'file';
-  content: string | Buffer;
+  content: () => string | Buffer;
 }>;
 
 export type BundleResultBundle = {
   sourceMap: {
     path: string;
-    map: SourceMap;
-    content: string;
+    map: SourceMapGenerator;
   };
   js: {
     path: string;

--- a/packages/@romejs/core/common/types/client.ts
+++ b/packages/@romejs/core/common/types/client.ts
@@ -21,6 +21,7 @@ export const DEFAULT_CLIENT_FLAGS: ClientFlags = {
 
 export const DEFAULT_CLIENT_REQUEST_FLAGS: ClientRequestFlags = {
   collectMarkers: false,
+  timing: false,
 
   benchmark: false,
   benchmarkIterations: 10,
@@ -36,6 +37,7 @@ export type ClientRequestFlags = DiagnosticsPrinterFlags & {
   watch: boolean;
 
   // Debugging
+  timing: boolean;
   collectMarkers: boolean;
   benchmark: boolean;
   benchmarkIterations: number;

--- a/packages/@romejs/core/common/utils/executeMain.ts
+++ b/packages/@romejs/core/common/utils/executeMain.ts
@@ -6,7 +6,7 @@
  */
 
 import {UnknownObject} from '@romejs/typescript-helpers';
-import {SourceMap} from '@romejs/codec-source-map';
+import {SourceMapConsumer} from '@romejs/codec-source-map';
 import {sourceMapManager} from '@romejs/v8';
 import internalModule = require('module');
 
@@ -25,7 +25,7 @@ import {number0Neg1, coerce1, number0} from '@romejs/ob1';
 type ExecuteMainOptions = {
   path: AbsoluteFilePath;
   code: string;
-  sourceMap: SourceMap;
+  sourceMap?: SourceMapConsumer;
   globals?: UnknownObject;
 };
 
@@ -103,7 +103,9 @@ export default async function executeMain(
   }
 
   // Execute the script if there was no syntax error
-  sourceMapManager.addSourceMap(filename, sourceMap);
+  if (sourceMap !== undefined) {
+    sourceMapManager.addSourceMap(filename, () => sourceMap);
+  }
   await script.runInContext(context);
   return {syntaxError: undefined};
 }

--- a/packages/@romejs/core/master/MasterRequest.ts
+++ b/packages/@romejs/core/master/MasterRequest.ts
@@ -133,6 +133,7 @@ export default class MasterRequest {
     this.client = opts.client;
     this.id = requestIdCounter++;
     this.markers = [];
+    this.start = Date.now();
 
     this.normalizedCommandFlags = {
       flags: {},
@@ -140,6 +141,7 @@ export default class MasterRequest {
     };
   }
 
+  start: number;
   client: MasterClient;
   query: MasterQueryRequest;
   master: Master;
@@ -164,6 +166,13 @@ export default class MasterRequest {
   teardown(
     res: undefined | MasterQueryResponse,
   ): undefined | MasterQueryResponse {
+    // Output timing information
+    if (this.query.requestFlags.timing) {
+      const end = Date.now();
+      this.reporter.info(`Request took <duration emphasis>${String(end -
+        this.start)}</duration>`);
+    }
+
     if (res !== undefined) {
       // If the query asked for no data then strip all diagnostics and data values
       if (this.query.noData) {

--- a/packages/@romejs/core/master/bundler/BundleRequest.ts
+++ b/packages/@romejs/core/master/bundler/BundleRequest.ts
@@ -33,6 +33,7 @@ import WorkerQueue from '../WorkerQueue';
 export type BundleOptions = {
   prefix?: string;
   interpreter?: string;
+  deferredSourceMaps?: boolean;
 };
 
 export default class BundleRequest {
@@ -49,8 +50,8 @@ export default class BundleRequest {
     resolvedEntry: AbsoluteFilePath;
     options: BundleOptions;
   }) {
+    this.options = options;
     this.reporter = reporter;
-    this.interpreter = options.interpreter;
     this.bundler = bundler;
     this.cached = true;
     this.mode = mode;
@@ -79,7 +80,7 @@ export default class BundleRequest {
     });
   }
 
-  interpreter: undefined | string;
+  options: BundleOptions;
   cached: boolean;
   reporter: Reporter;
   bundler: Bundler;
@@ -207,11 +208,26 @@ export default class BundleRequest {
     return res;
   }
 
-  async stepCombine(order: DependencyOrder): Promise<BundleRequestResult> {
+  stepCombine(
+    order: DependencyOrder,
+    forceSourceMaps: boolean,
+  ): BundleRequestResult {
     const {files} = order;
     const {inlineSourceMap} = this.bundler.config;
     const {graph} = this.bundler;
     const {resolvedEntry, mode, sourceMap} = this;
+
+    // We allow deferring the generation of source maps. We don't do this by default as it's slower than generating them upfront
+    // which is what most callers need. But for things like tests, we want to lazily compute the source map only when diagnostics
+    // are present.
+    let deferredSourceMaps = !forceSourceMaps &&
+        this.options.deferredSourceMaps ===
+        true;
+    if (deferredSourceMaps) {
+      sourceMap.addMaterializer(() => {
+        this.stepCombine(order, true);
+      });
+    }
 
     let content: string = '';
     let lineOffset: number = 0;
@@ -219,9 +235,11 @@ export default class BundleRequest {
     function push(str: string) {
       str += '\n';
       content += str;
-      for (let cha of str) {
-        if (cha === '\n') {
-          lineOffset++;
+      if (!deferredSourceMaps) {
+        for (let cha of str) {
+          if (cha === '\n') {
+            lineOffset++;
+          }
         }
       }
     }
@@ -231,6 +249,10 @@ export default class BundleRequest {
       sourceContent: string,
       mappings: Mappings,
     ) {
+      if (deferredSourceMaps) {
+        return;
+      }
+
       sourceMap.setSourceContent(filename, sourceContent);
       for (const mapping of mappings) {
         sourceMap.addMapping({
@@ -243,7 +265,7 @@ export default class BundleRequest {
       }
     }
 
-    const {interpreter} = this;
+    const {interpreter} = this.options;
     if (interpreter !== undefined) {
       push(`#!${interpreter}\n`);
     }
@@ -349,7 +371,7 @@ export default class BundleRequest {
     return {
       diagnostics: this.diagnostics.getDiagnostics(),
       content,
-      map: sourceMap.toJSON(),
+      sourceMap: this.sourceMap,
       cached: this.cached,
       assets: this.assets,
     };
@@ -361,7 +383,7 @@ export default class BundleRequest {
 
   abort(): BundleRequestResult {
     return {
-      map: this.sourceMap.toJSON(),
+      sourceMap: this.sourceMap,
       content: '',
       diagnostics: this.diagnostics.getDiagnostics(),
       cached: false,
@@ -382,6 +404,6 @@ export default class BundleRequest {
     }
 
     // Combine
-    return await this.stepCombine(order);
+    return await this.stepCombine(order, false);
   }
 }

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -124,6 +124,7 @@ export default class Bundler {
   // This will take multiple entry points and do some magic to make them more efficient to build in parallel
   async bundleMultiple(
     entries: Array<AbsoluteFilePath>,
+    options: BundleOptions = {},
   ): Promise<Map<AbsoluteFilePath, BundleResult>> {
     // Clone so we can mess with it
     entries = [...entries];
@@ -176,7 +177,7 @@ export default class Bundler {
       const promise = (async () => {
         const text = markup`<filelink target="${entry.join()}" />`;
         progress.pushText(text);
-        map.set(entry, await this.bundle(entry, {}, silentReporter));
+        map.set(entry, await this.bundle(entry, options, silentReporter));
         progress.popText(text);
         progress.tick();
       })();
@@ -219,7 +220,7 @@ export default class Bundler {
     const bundleBuddyStats = this.graph.getBundleBuddyStats(this.entries);
     files.set('bundlebuddy.json', {
       kind: 'stats',
-      content: JSON.stringify(bundleBuddyStats, null, '  '),
+      content: () => JSON.stringify(bundleBuddyStats, null, '  '),
     });
 
     // TODO ensure that __dirname is relative to the project root
@@ -232,7 +233,7 @@ export default class Bundler {
           if (!files.has(relative)) {
             files.set(relative, {
               kind: 'file',
-              content: buffer,
+              content: () => buffer,
             });
           }
         },
@@ -241,7 +242,7 @@ export default class Bundler {
       // Add a package.json with updated values
       files.set('package.json', {
         kind: 'manifest',
-        content: JSON.stringify(newManifest, undefined, '  '),
+        content: () => JSON.stringify(newManifest, undefined, '  '),
       });
     }
 
@@ -355,8 +356,6 @@ export default class Bundler {
       reporter.warn('Bundle was built completely from cache');
     }
 
-    const serialMap = JSON.stringify(res.map);
-
     const prefix = options.prefix === undefined ? '' : `${options.prefix}/`;
     const jsPath = `${prefix}index.js`;
     const mapPath = `${jsPath}.map`;
@@ -364,17 +363,18 @@ export default class Bundler {
     const files: BundlerFiles = new Map();
     files.set(jsPath, {
       kind: 'entry',
-      content: res.content,
+      content: () => res.content,
     });
+
     files.set(mapPath, {
       kind: 'sourcemap',
-      content: serialMap,
+      content: () => res.sourceMap.toJSON(),
     });
 
     for (const [relative, buffer] of res.assets) {
       files.set(relative, {
         kind: 'asset',
-        content: buffer,
+        content: () => buffer,
       });
     }
 
@@ -385,8 +385,7 @@ export default class Bundler {
       },
       sourceMap: {
         path: mapPath,
-        map: res.map,
-        content: serialMap,
+        map: res.sourceMap,
       },
     };
     return {

--- a/packages/@romejs/core/master/commands/run.ts
+++ b/packages/@romejs/core/master/commands/run.ts
@@ -38,7 +38,7 @@ export default createMasterCommand(
           type: 'executeCode',
           filename: path.join(),
           code: entry.js.content,
-          map: entry.sourceMap.map,
+          map: entry.sourceMap.map.serialize(),
         };
       }
 

--- a/packages/@romejs/core/master/testing/types.ts
+++ b/packages/@romejs/core/master/testing/types.ts
@@ -6,7 +6,7 @@
  */
 
 import {Diagnostics} from '@romejs/diagnostics';
-import {SourceMap} from '@romejs/codec-source-map';
+import {SourceMapGenerator} from '@romejs/codec-source-map';
 import {AbsoluteFilePath} from '@romejs/path';
 import {MasterRequest, TestWorkerBridge} from '@romejs/core';
 import {CoverageFile, InspectorClient} from '@romejs/v8';
@@ -14,7 +14,7 @@ import child = require('child_process');
 
 export type TestSource = {
   code: string;
-  sourceMap: SourceMap;
+  sourceMap: SourceMapGenerator;
   path: AbsoluteFilePath;
 };
 

--- a/packages/@romejs/core/test-worker/TestWorkerRunner.ts
+++ b/packages/@romejs/core/test-worker/TestWorkerRunner.ts
@@ -97,12 +97,11 @@ export default class TestWorkerRunner {
 
   // execute the test file and discover tests
   async discoverTests() {
-    const {code, sourceMap} = this.opts;
+    const {code} = this.opts;
 
     const res = await executeMain({
       path: this.file.real,
       code,
-      sourceMap,
       globals: this.getEnvironment(),
     });
 

--- a/packages/@romejs/core/test-worker/TestWorkerRunner.ts
+++ b/packages/@romejs/core/test-worker/TestWorkerRunner.ts
@@ -180,21 +180,18 @@ export default class TestWorkerRunner {
       filename,
       cleanFrames(frames) {
         // TODO we should actually get the frames before module init and do it that way
-
         // Remove everything before the original module factory
         let latestTestWorkerFrame = frames.find((frame, i) => {
           if (frame.typeName === 'global' && frame.methodName === undefined &&
                 frame.functionName ===
                 undefined) {
             // We are the global.<anonymous> frame
-
             // Now check for Script.runInContext
             const nextFrame = frames[i + 1];
             if (nextFrame !== undefined && nextFrame.typeName === 'Script' &&
                   nextFrame.methodName ===
                   'runInContext') {
               // Yes!
-
               // TODO also check for ___$romejs$core$common$utils$executeMain_ts$default (packages/romejs/core/common/utils/executeMain.ts:69:17)
               return true;
             }
@@ -206,8 +203,8 @@ export default class TestWorkerRunner {
         // And if there was no module factory frame, then we must be inside of a test
         if (latestTestWorkerFrame === undefined) {
           latestTestWorkerFrame = frames.find((frame) => {
-            return frame.filename !== undefined && frame.filename.includes(
-              'core/test-worker',
+            return frame.typeName !== undefined && frame.typeName.includes(
+              '$TestWorkerRunner',
             );
           });
         }

--- a/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
+++ b/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
@@ -226,9 +226,11 @@ export default class DiagnosticsProcessor {
     if (!sourceMaps.hasAny()) {
       return diag;
     }
+
     function check(filename: undefined | string) {
       return filename !== undefined && sourceMaps.has(filename);
     }
+
     // Check location
     let {location} = diag;
     const hasLocation = check(location.filename);
@@ -272,11 +274,11 @@ export default class DiagnosticsProcessor {
             frames: item.frames.map((frame) => {
               const {filename, line, column} = frame;
               if (filename === undefined || line === undefined || column ===
-                  undefined) {
+                  undefined || !sourceMaps.has(filename)) {
                 return frame;
               }
 
-              const resolved = sourceMaps.exactOriginalPositionFor(
+              const resolved = sourceMaps.approxOriginalPositionFor(
                 filename,
                 line,
                 column,

--- a/packages/@romejs/js-formatter/Printer.ts
+++ b/packages/@romejs/js-formatter/Printer.ts
@@ -109,7 +109,7 @@ export default class Printer {
 
     this.inputSourceMap = opts.inputSourceMap === undefined
       ? undefined
-      : new SourceMapConsumer(opts.inputSourceMap);
+      : SourceMapConsumer.fromJSON(opts.inputSourceMap);
   }
 
   compact: boolean;
@@ -722,7 +722,9 @@ export default class Printer {
     const {options} = this;
 
     const map = new SourceMapGenerator({
-      file: options.sourceMapTarget,
+      file: options.sourceMapTarget === undefined
+        ? 'unknown'
+        : options.sourceMapTarget,
       sourceRoot: options.sourceRoot,
     });
 
@@ -734,6 +736,6 @@ export default class Printer {
       map.addMapping(mapping);
     }
 
-    return map.toJSON();
+    return map.serialize();
   }
 }

--- a/packages/@romejs/v8/CoverageCollector.ts
+++ b/packages/@romejs/v8/CoverageCollector.ts
@@ -12,7 +12,7 @@ import {
   CoverageLocationRange,
   CoverageRangeWithMetadata,
 } from '@romejs/v8';
-import {SourceMap, SourceMapConsumer} from '@romejs/codec-source-map';
+import {SourceMapConsumer} from '@romejs/codec-source-map';
 import {Position} from '@romejs/parser-core';
 import {urlToFilename} from './utils';
 import {
@@ -47,10 +47,10 @@ export default class CoverageCollector {
   sourceMaps: Map<string, {
     code: string;
     ranges: Array<CoverageRangeWithMetadata>;
-    map: SourceMap;
+    map: SourceMapConsumer;
   }>;
 
-  addSourceMap(filename: string, code: string, map: SourceMap) {
+  addSourceMap(filename: string, code: string, map: SourceMapConsumer) {
     this.sourceMaps.set(filename, {
       ranges: [],
       map,
@@ -145,12 +145,11 @@ export default class CoverageCollector {
       }
 
       //
-      const sourceMap = new SourceMapConsumer(map);
       for (const {kind, startOffset, endOffset, count} of ranges) {
         const originalStart = findIndex(coerce0(startOffset));
         const originalEnd = findIndex(coerce0(endOffset));
 
-        const sourceStart = sourceMap.approxOriginalPositionFor(
+        const sourceStart = map.approxOriginalPositionFor(
           originalStart.line,
           originalStart.column,
         );
@@ -158,7 +157,7 @@ export default class CoverageCollector {
           continue;
         }
 
-        const sourceEnd = sourceMap.approxOriginalPositionFor(
+        const sourceEnd = map.approxOriginalPositionFor(
           originalEnd.line,
           originalEnd.column,
         );

--- a/packages/@romejs/v8/sourceMapManager.ts
+++ b/packages/@romejs/v8/sourceMapManager.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {SourceMap, SourceMapConsumer} from '@romejs/codec-source-map';
+import {SourceMapConsumer} from '@romejs/codec-source-map';
 import {ErrorFrame} from '@romejs/v8';
 import {coerce1, coerce1to0, Number1, Number0} from '@romejs/ob1';
 import {
@@ -26,7 +26,7 @@ let inited: boolean = false;
 const maps: Map<string, SourceMapConsumer> = new Map();
 
 // In case we want to defer the reading of a source map completely (parsing is always deferred)
-const factories: Map<string, () => SourceMap> = new Map();
+const factories: Map<string, () => SourceMapConsumer> = new Map();
 
 function prepareStackTrace(err: Error, frames: Array<NodeJS.CallSite>) {
   try {
@@ -229,19 +229,15 @@ export function resolveLocation(
   };
 }
 
-export function addSourceMap(filename: string, map: SourceMap) {
-  return addSourceMapFactory(filename, () => map);
-}
-
 // Add a source map factory. We jump through some hoops to return a function to remove the source map.
 // We make sure not to remove the source map if it's been subsequently added by another call.
-export function addSourceMapFactory(
+export function addSourceMap(
   filename: string,
-  factory: () => SourceMap,
+  factory: () => SourceMapConsumer,
 ): () => void {
   init();
 
-  let map: undefined | SourceMap;
+  let map: undefined | SourceMapConsumer;
   function factoryCapture() {
     map = factory();
     return map;
@@ -269,9 +265,8 @@ export function getSourceMap(filename: string): undefined | SourceMapConsumer {
   if (factory !== undefined) {
     factories.delete(filename);
     const map = factory();
-    const consumer = new SourceMapConsumer(map);
-    maps.set(filename, consumer);
-    return consumer;
+    maps.set(filename, map);
+    return map;
   }
 
   return undefined;

--- a/packages/rome/index.ts
+++ b/packages/rome/index.ts
@@ -110,11 +110,11 @@ export const compile = wrapForErrors(async function(opts: {
   throwDiagnostics(res.diagnostics);
 
   // Build source map
-  const sourceMapGenerator = new SourceMapGenerator({});
+  const sourceMapGenerator = new SourceMapGenerator({file: 'unknown'});
   for (const mapping of res.mappings) {
     sourceMapGenerator.addMapping(mapping);
   }
-  const sourceMap = sourceMapGenerator.toJSON();
+  const sourceMap = sourceMapGenerator.serialize();
 
   return {
     cacheKey,


### PR DESCRIPTION
This PR improves bundler performance when bundling multiple files even more. The focus of this was to make `rome test` even faster. There was a lot of low hanging fruit. I've done the following improvements.

- We allow passing in markup to progress bars. This markup is then stripped to just plain text. The display of a progress bar is debounced, so we were doing some unnecessary work for progress bar text that ever even made it to the console.
- Deferred the creation of source maps. This made it so we don't have any overhead of source maps until we've actually.
- Allowed a `SourceMapConsumer` to be constructed with raw mappings
- Cached `DependencyNode#resolveImports`.
- Disabled coverage by default for `rome test`. Still enabled for `rome ci`. You can explicitly use `rome test --coverage` if you want it. Having coverage on by default requires us to always have source maps.