### PR TITLE
escape `\b` in regular expressions

### DIFF
--- a/packages/@romejs/codec-js-regexp/index.ts
+++ b/packages/@romejs/codec-js-regexp/index.ts
@@ -184,14 +184,9 @@ export const createRegExpParser = createParser(
               value: '\f',
             }, end);
 
-          case 'b':
-            return this.finishComplexToken('Character', {
-              escaped: false,
-              value: '\b',
-            }, end);
-
           case 'd':
           case 'D':
+          case 'b':
           case 'B':
           case 's':
           case 'S':


### PR DESCRIPTION
This is a PR that escapes `\b` in regular expressions which allows it to get parsed as `RegExpWordBoundaryCharacter` which previously wasn't happening.