### PR TITLE
Add dirty checks to `lint` and `ci`

### DIFF
--- a/packages/@romejs/cli-flags/serializeCLIFlags.ts
+++ b/packages/@romejs/cli-flags/serializeCLIFlags.ts
@@ -12,7 +12,8 @@ import {Number0, coerce0, number1, number0Neg1} from '@romejs/ob1';
 import {Dict} from '@romejs/typescript-helpers';
 
 type SerializeCLIData = {
-  prefix: undefined | string;
+  programName: undefined | string;
+  commandName: undefined | string;
   args: Array<string>;
   defaultFlags: Dict<unknown>;
   flags: Dict<unknown>;
@@ -31,7 +32,7 @@ export type SerializeCLITarget = {
   type: 'arg-range';
   from: number;
   to?: number;
-} | {type: 'none'};
+} | {type: 'none'} | {type: 'command'} | {type: 'program'};
 
 function normalizeFlagValue(val: unknown): unknown {
   if (val === 'true') {
@@ -45,31 +46,65 @@ function normalizeFlagValue(val: unknown): unknown {
 
 export function serializeCLIFlags(
   data: SerializeCLIData,
-  cliTarget: SerializeCLITarget,
+  target: SerializeCLITarget,
 ): DiagnosticLocation {
-  const {args, flags, defaultFlags} = data;
+  const {args, flags, programName, commandName, defaultFlags} = data;
 
-  let code = `$ `;
-  if (data.prefix !== undefined) {
-    code += `${data.prefix} `;
-  }
   let startColumn: Number0 = number0Neg1;
   let endColumn: Number0 = number0Neg1;
+  let code = `$ `;
+
+  function setStartColumn() {
+    startColumn = coerce0(code.length);
+  }
+
+  function setEndColumn() {
+    // Never point to a space
+    if (code[code.length - 1] === ' ') {
+      endColumn = coerce0(code.length - 1);
+    } else {
+      endColumn = coerce0(code.length);
+    }
+  }
+
+  if (programName !== undefined) {
+    if (target.type === 'program') {
+      setStartColumn();
+    }
+
+    code += `${programName} `;
+
+    if (target.type === 'program') {
+      setEndColumn();
+    }
+  }
+
+  if (commandName !== undefined) {
+    if (target.type === 'command') {
+      setStartColumn();
+    }
+
+    code += `${commandName} `;
+
+    if (target.type === 'command') {
+      setEndColumn();
+    }
+  }
 
   // Add args
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
     let isTarget = false;
-    if (cliTarget.type === 'arg' && i === cliTarget.key) {
+    if (target.type === 'arg' && i === target.key) {
       isTarget = true;
     }
-    if (cliTarget.type === 'arg-range' && cliTarget.from === i) {
+    if (target.type === 'arg-range' && target.from === i) {
       isTarget = true;
     }
 
     if (isTarget) {
-      startColumn = coerce0(code.length);
+      setStartColumn();
     }
 
     code += `${arg} `;
@@ -77,15 +112,13 @@ export function serializeCLIFlags(
     let isEndTarget = isTarget;
 
     // We are the end target if we're within the from-to range or we're greater than from with no to
-    if (cliTarget.type === 'arg-range' && i > cliTarget.from &&
-        (cliTarget.to ===
-            undefined ||
-          cliTarget.to <= i)) {
+    if (target.type === 'arg-range' && i > target.from && (target.to ===
+        undefined || target.to <= i)) {
       isEndTarget = true;
     }
 
     if (isEndTarget) {
-      endColumn = coerce0(code.length - 1);
+      setEndColumn();
     }
   }
 
@@ -98,10 +131,10 @@ export function serializeCLIFlags(
       continue;
     }
 
-    const isTarget = cliTarget.type === 'flag' && key === cliTarget.key;
+    const isTarget = target.type === 'flag' && key === target.key;
 
     if (isTarget) {
-      startColumn = coerce0(code.length);
+      setStartColumn();
     }
 
     const flagPrefix = data.shorthandFlags.has(key) ? '-' : '--';
@@ -115,9 +148,9 @@ export function serializeCLIFlags(
     // Booleans are always indicated with just their flag
     if (typeof val !== 'boolean') {
       // Only point to the value for flags that specify it
-      if (isTarget && cliTarget.type === 'flag' &&
-          (cliTarget.target === 'value' ||
-            cliTarget.target === 'inner-value')) {
+      if (isTarget && target.type === 'flag' && (target.target === 'value' ||
+            target.target ===
+            'inner-value')) {
         startColumn = coerce0(code.length);
       }
 
@@ -126,7 +159,7 @@ export function serializeCLIFlags(
     }
 
     if (isTarget) {
-      endColumn = coerce0(code.length - 1);
+      setEndColumn();
     }
   }
 

--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -109,6 +109,9 @@ export default async function cli() {
             review: c.get('review').asBoolean(
               DEFAULT_CLIENT_REQUEST_FLAGS.review,
             ),
+            allowDirty: c.get('allowDirty').asBoolean(
+              DEFAULT_CLIENT_REQUEST_FLAGS.allowDirty,
+            ),
             watch: c.get('watch').asBoolean(DEFAULT_CLIENT_REQUEST_FLAGS.watch),
             fieri: c.get('fieri').asBoolean(DEFAULT_CLIENT_REQUEST_FLAGS.fieri),
             focus: c.get('focus').asString(DEFAULT_CLIENT_REQUEST_FLAGS.focus),
@@ -351,7 +354,9 @@ export default async function cli() {
     }
 
     case 'INVALID_REQUEST': {
-      await p.showHelp();
+      if (res.showHelp) {
+        await p.showHelp();
+      }
       process.exit(1);
       break;
     }

--- a/packages/@romejs/codec-js-manifest/name.ts
+++ b/packages/@romejs/codec-js-manifest/name.ts
@@ -6,14 +6,15 @@
  */
 
 import {number0, Number0, coerce0, inc, add} from '@romejs/ob1';
-import {escapeMarkup} from '@romejs/string-markup';
-import {DiagnosticAdvice} from '@romejs/diagnostics';
+import {
+  DiagnosticDescriptionOptionalCategory,
+  descriptions,
+} from '@romejs/diagnostics';
 
 type NormalizeNameUnexpected = (opts: {
-  message: string;
+  description: DiagnosticDescriptionOptionalCategory;
   start?: Number0;
   end?: Number0;
-  advice?: DiagnosticAdvice;
   at?: 'prefix';
 }) => void;
 
@@ -41,7 +42,7 @@ function validateNamePart(
 
     if (isOrg && char === '@' && i === 0) {
       unexpected({
-        message: 'Redundant <emphasis>@</emphasis> in org name',
+        description: descriptions.MANIFEST.REDUNDANT_ORG_NAME_START,
         start: add(offset, i),
       });
     } else if (!isOrgPart && char === '/') {
@@ -69,12 +70,10 @@ function validateNamePart(
     } else if (char.match(/[A-Za-z0-9\-_.]/)) {
       normalizedName += char;
     } else {
-      unexpected(
-        {
-          message: `The character <emphasis>${escapeMarkup(char)}</emphasis> isn't allowed`,
-          start: add(offset, i),
-        },
-      );
+      unexpected({
+        description: descriptions.MANIFEST.INVALID_NAME_CHAR(char),
+        start: add(offset, i),
+      });
     }
   }
 
@@ -88,7 +87,7 @@ export function normalizeName(opts: NormalizeNameOptions): string {
   if (name.length > 214) {
     unexpected({
       at: 'prefix',
-      message: `cannot exceed 214 characters`,
+      description: descriptions.MANIFEST.NAME_EXCEEDS,
     });
     name = name.slice(0, 214);
   }
@@ -96,7 +95,7 @@ export function normalizeName(opts: NormalizeNameOptions): string {
   if (name[0] === '.' || name[0] === '_') {
     unexpected({
       at: 'prefix',
-      message: `cannot start with a dot or underscore`,
+      description: descriptions.MANIFEST.INVALID_NAME_START,
       start: number0,
     });
     name = name.slice(1);
@@ -121,7 +120,7 @@ export function normalizeName(opts: NormalizeNameOptions): string {
     if (packageName === undefined) {
       unexpected({
         at: 'prefix',
-        message: `contains an org but no package name`,
+        description: descriptions.MANIFEST.ORG_WITH_NO_PACKAGE_NAME,
         start: offset,
       });
 
@@ -143,7 +142,7 @@ export function normalizeName(opts: NormalizeNameOptions): string {
       if (other.length > 0) {
         unexpected({
           at: 'prefix',
-          message: `contains too many name separators`,
+          description: descriptions.MANIFEST.ORG_TOO_MANY_PARTS,
           start: offset,
         });
       }

--- a/packages/@romejs/consume/types.ts
+++ b/packages/@romejs/consume/types.ts
@@ -12,7 +12,6 @@ import {
 } from '@romejs/diagnostics';
 import Consumer from './Consumer';
 import {UnknownFilePath} from '@romejs/path';
-import {Number0, Number1} from '@romejs/ob1';
 
 export type ConsumeComments = Array<string>;
 
@@ -60,8 +59,8 @@ type ConsumePropertyPrimitiveDefinition =
 
 type ConsumePropertyNumberRangeDefinition = ConsumePropertyDefinitionBase & {
   type: 'number-range';
-  min: undefined | Number0 | Number1 | number;
-  max: undefined | Number0 | Number1 | number;
+  min: undefined | number;
+  max: undefined | number;
 };
 
 export type ConsumePropertyDefinition =

--- a/packages/@romejs/core/client/commands/lint.ts
+++ b/packages/@romejs/core/client/commands/lint.ts
@@ -46,7 +46,7 @@ export default createLocalCommand<LintCommandFlags>(
   {
     category: commandCategories.CODE_QUALITY,
     description: 'run lint against a set of files',
-    allowRequestFlags: ['watch', 'review'],
+    allowRequestFlags: ['watch', 'review', 'allowDirty'],
     usage: '',
     examples: [],
 
@@ -219,6 +219,9 @@ export default createLocalCommand<LintCommandFlags>(
         commandFlags: {
           fix: true,
           compilerOptions: lintOptionsPerFile,
+        },
+        requestFlags: {
+          allowDirty: true,
         },
       }, 'master');
       return res2;

--- a/packages/@romejs/core/common/bridges/MasterBridge.ts
+++ b/packages/@romejs/core/common/bridges/MasterBridge.ts
@@ -60,6 +60,7 @@ export type MasterQueryResponseDiagnostics = {
 export type MasterQueryResponseInvalid = {
   type: 'INVALID_REQUEST';
   diagnostics: Diagnostics;
+  showHelp: boolean;
 };
 
 export type MasterQueryResponse =

--- a/packages/@romejs/core/common/commands.ts
+++ b/packages/@romejs/core/common/commands.ts
@@ -17,7 +17,7 @@ export type SharedCommand<Flags extends Dict<unknown>> = {
     description: string;
     command: string;
   }>;
-  allowRequestFlags?: Array<'review' | 'watch'>;
+  allowRequestFlags?: Array<'review' | 'watch' | 'allowDirty'>;
 };
 
 export const commandCategories = {

--- a/packages/@romejs/core/common/types/client.ts
+++ b/packages/@romejs/core/common/types/client.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CLIENT_FLAGS: ClientFlags = {
 export const DEFAULT_CLIENT_REQUEST_FLAGS: ClientRequestFlags = {
   collectMarkers: false,
   timing: false,
+  allowDirty: false,
 
   benchmark: false,
   benchmarkIterations: 10,
@@ -37,6 +38,7 @@ export const DEFAULT_CLIENT_REQUEST_FLAGS: ClientRequestFlags = {
 export type ClientRequestFlags = DiagnosticsPrinterFlags & {
   watch: boolean;
   review: boolean;
+  allowDirty: boolean;
 
   // Debugging
   timing: boolean;

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -132,7 +132,7 @@ function validateAllowedRequestFlag(
   masterCommand: MasterCommand<Dict<unknown>>,
 ) {
   const allowRequestFlags = masterCommand.allowRequestFlags || [];
-  if (req.query.requestFlags && !allowRequestFlags.includes(flagKey)) {
+  if (req.query.requestFlags[flagKey] && !allowRequestFlags.includes(flagKey)) {
     throw req.throwDiagnosticFlagError({
       description: descriptions.FLAGS.DISALLOWED_REQUEST_FLAG(flagKey),
       target: {type: 'flag', key: flagKey},

--- a/packages/@romejs/core/master/commands/ci.ts
+++ b/packages/@romejs/core/master/commands/ci.ts
@@ -43,6 +43,7 @@ export default createMasterCommand({
   description: 'run lint and tests',
   usage: '',
   examples: [],
+  allowRequestFlags: ['allowDirty'],
 
   defineFlags(consumer: Consumer): Flags {
     return {
@@ -52,6 +53,10 @@ export default createMasterCommand({
 
   async callback(req: MasterRequest, flags: Flags): Promise<void> {
     const {reporter} = req;
+
+    if (flags.fix) {
+      await req.assertCleanVSC();
+    }
 
     reporter.heading('Running lint');
     await runChildCommand(req, async () => {

--- a/packages/@romejs/core/master/commands/config.ts
+++ b/packages/@romejs/core/master/commands/config.ts
@@ -11,6 +11,7 @@ import {createMasterCommand} from '../commands';
 import {modifyProjectConfig, assertHardMeta} from '@romejs/project';
 import {createUnknownFilePath} from '@romejs/path';
 import {markup} from '@romejs/string-markup';
+import {descriptions} from '@romejs/diagnostics';
 
 export default createMasterCommand(
   {
@@ -96,9 +97,12 @@ export default createMasterCommand(
         }
 
         default:
-          throw req.throwDiagnosticFlagError(`Unknown action ${action}`, {
-            type: 'arg',
-            key: 0,
+          throw req.throwDiagnosticFlagError({
+            description: descriptions.FLAGS.UNKNOWN_ACTION(action),
+            target: {
+              type: 'arg',
+              key: 0,
+            },
           });
       }
 

--- a/packages/@romejs/core/master/commands/lint.ts
+++ b/packages/@romejs/core/master/commands/lint.ts
@@ -17,6 +17,10 @@ export default createMasterCommand<LintCommandFlags>({
   async callback(req: MasterRequest, flags: LintCommandFlags): Promise<void> {
     const {reporter} = req;
 
+    if (req.query.requestFlags.review || flags.fix) {
+      await req.assertCleanVSC();
+    }
+
     const fixLocation = flags.fix === false
       ? undefined
       : req.getDiagnosticPointerFromFlags({
@@ -30,9 +34,7 @@ export default createMasterCommand<LintCommandFlags>({
       // No arguments expected when using this flag
       req.expectArgumentLength(0);
 
-      const client = await req.master.projectManager.getVCSClient(
-        await req.assertClientCwdProject(),
-      );
+      const client = await req.getVCSClient();
       const target = flags.changed === '' ? client.trunkBranch : flags.changed;
       args = await client.getModifiedFiles(target);
 

--- a/packages/@romejs/core/master/fs/Resolver.ts
+++ b/packages/@romejs/core/master/fs/Resolver.ts
@@ -155,11 +155,14 @@ const QUERY_RESPONSE_MISSING: ResolverQueryResponseMissing = {
   source: undefined,
 };
 
-export type ResolverQueryResponse =
-  | ResolverQueryResponseFound
+export type ResolverQueryResponseNotFound =
   | ResolverQueryResponseMissing
   | ResolverQueryResponseFetchError
   | ResolverQueryResponseUnsupported;
+
+export type ResolverQueryResponse =
+  | ResolverQueryResponseFound
+  | ResolverQueryResponseNotFound;
 
 function shouldReturnQueryResponse(res: ResolverQueryResponse): boolean {
   return res.type === 'FOUND' || res.source !== undefined;

--- a/packages/@romejs/core/master/project/ProjectManager.ts
+++ b/packages/@romejs/core/master/project/ProjectManager.ts
@@ -543,7 +543,7 @@ export default class ProjectManager {
   }
 
   async getVCSClient(project: ProjectDefinition): Promise<VCSClient> {
-    const client = await getVCSClient(project.config.vcs.root);
+    const client = await this.maybeGetVCSClient(project);
 
     if (client === undefined) {
       const {
@@ -567,6 +567,12 @@ export default class ProjectManager {
     } else {
       return client;
     }
+  }
+
+  async maybeGetVCSClient(
+    project: ProjectDefinition,
+  ): Promise<undefined | VCSClient> {
+    return await getVCSClient(project.config.vcs.root);
   }
 
   async addProject(

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -104,6 +104,7 @@ export type DiagnosticCategory =
   | 'typeCheck/undeclaredVariable'
   | 'typeCheck/unknownImport'
   | 'typeCheck/unknownProperty'
+  | 'vsc/dirty'
   | 'v8/syntaxError';
 
 export type DiagnosticCategoryPrefix =

--- a/packages/@romejs/diagnostics/helpers.ts
+++ b/packages/@romejs/diagnostics/helpers.ts
@@ -11,6 +11,7 @@ import diff from '@romejs/string-diff';
 import {Position} from '@romejs/parser-core';
 import {get1} from '@romejs/ob1';
 import {NEWLINE} from '@romejs/js-parser-utils';
+import {markup, escapeMarkup} from '@romejs/string-markup';
 
 type BuildSuggestionAdviceOptions = {
   minRating?: number;
@@ -58,14 +59,14 @@ export function buildSuggestionAdvice(
       {
         type: 'log',
         category: 'info',
-        message: `Did you mean <emphasis>${topRatingFormatted}</emphasis> or <emphasis>${strings[0]}</emphasis>?`,
+        message: markup`Did you mean <emphasis>${topRatingFormatted}</emphasis> or <emphasis>${strings[0]}</emphasis>?`,
       },
     );
   } else {
     advice.push({
       type: 'log',
       category: 'info',
-      message: `Did you mean <emphasis>${topRatingFormatted}</emphasis>?`,
+      message: markup`Did you mean <emphasis>${topRatingFormatted}</emphasis>?`,
     });
 
     advice.push({
@@ -82,7 +83,7 @@ export function buildSuggestionAdvice(
 
       advice.push({
         type: 'list',
-        list: strings,
+        list: strings.map((str) => escapeMarkup(str)),
         truncate: true,
       });
     }

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -78,6 +78,12 @@ export type DiagnosticDescription = {
   advice?: DiagnosticAdvice;
 };
 
+export type DiagnosticDescriptionOptionalCategory = {
+  category?: DiagnosticCategory;
+  message: DiagnosticBlessedMessage;
+  advice?: DiagnosticAdvice;
+};
+
 // TS doesn't have opaque types so we need to use an intermediate object
 export type DiagnosticBlessedMessage = {
   type: 'PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE';

--- a/packages/@romejs/js-parser/index.test.ts
+++ b/packages/@romejs/js-parser/index.test.ts
@@ -36,7 +36,7 @@ const promise = createFixtureTests(
     const sourceTypeProp = options.get('sourceType');
     const sourceType = sourceTypeProp.asString('script');
     if (sourceType !== 'module' && sourceType !== 'script') {
-      throw sourceTypeProp.unexpected('Expected either script or module');
+      throw sourceTypeProp.unexpected();
     }
 
     const allowReturnOutsideFunction = options.get('allowReturnOutsideFunction').asBoolean(

--- a/packages/@romejs/ob1/index.ts
+++ b/packages/@romejs/ob1/index.ts
@@ -62,6 +62,13 @@ export function get1(x: undefined | Number1): undefined | number {
   return x;
 }
 
+export function get(x: UnknownNumber): number;
+export function get(x: undefined): undefined;
+export function get(x: undefined | UnknownNumber): undefined | number {
+  // @ts-ignore
+  return x;
+}
+
 // Coerce a number into a 0-offset
 export function coerce0(x: number): Number0;
 export function coerce0(x: undefined): undefined;

--- a/packages/@romejs/parser-core/index.ts
+++ b/packages/@romejs/parser-core/index.ts
@@ -24,7 +24,6 @@ import {
   DiagnosticCategory,
   DiagnosticDescription,
   DiagnosticsError,
-  createBlessedDiagnosticMessage,
   descriptions,
   catchDiagnosticsSync,
 } from '@romejs/diagnostics';
@@ -40,7 +39,6 @@ import {
   sub,
   dec,
 } from '@romejs/ob1';
-import {escapeMarkup} from '@romejs/string-markup';
 import {UnknownFilePath, createUnknownFilePath} from '@romejs/path';
 import {Class, OptionalProps} from '@romejs/typescript-helpers';
 import {removeCarriageReturn} from '@romejs/string-utils';
@@ -422,23 +420,17 @@ export class ParserCore<Tokens extends TokensShape, State> {
 
     // Normalize message, we need to be defensive here because it could have been called while tokenizing the first token
     if (metadata === undefined) {
-      let message;
       if (currentToken !== undefined && start !== undefined && start.index ===
           currentToken.start) {
-        message = createBlessedDiagnosticMessage(
-          `Unexpected ${currentToken.type}`,
-        );
+        metadata = descriptions.PARSER_CORE.UNEXPECTED(currentToken.type);
       } else {
         if (this.isEOF(start.index)) {
-          message = createBlessedDiagnosticMessage('Unexpected end of file');
+          metadata = descriptions.PARSER_CORE.UNEXPECTED_EOF;
         } else {
           const char = this.input[get0(start.index)];
-          message = createBlessedDiagnosticMessage(
-            `Unexpected character <emphasis>${escapeMarkup(char)}</emphasis>`,
-          );
+          metadata = descriptions.PARSER_CORE.UNEXPECTED_CHARACTER(char);
         }
       }
-      metadata = {message};
     }
 
     const metadataWithCategory: DiagnosticDescription = {

--- a/packages/@romejs/project/load.ts
+++ b/packages/@romejs/project/load.ts
@@ -35,6 +35,7 @@ import crypto = require('crypto');
 
 import {ROME_CONFIG_PACKAGE_JSON_FIELD} from './constants';
 import {parseSemverRange} from '@romejs/codec-semver';
+import {descriptions} from '@romejs/diagnostics';
 
 const WATCHMAN_CONFIG_FILENAME = '.watchmanconfig';
 const IGNORE_FILENAMES = ['.gitignore', '.hgignore'];
@@ -46,18 +47,7 @@ function categoryExists(consumer: Consumer): boolean {
 
   const value = consumer.asUnknown();
   if (typeof value === 'boolean') {
-    consumer.unexpected(
-      `Expected an object here but got a boolean`,
-      {
-        advice: [
-          {
-            type: 'log',
-            category: 'info',
-            message: `You likely wanted \`{"enabled": ${String(value)}}\` instead`,
-          },
-        ],
-      },
-    );
+    consumer.unexpected(descriptions.PROJECT_CONFIG.BOOLEAN_CATEGORY(value));
     return false;
   }
 
@@ -395,11 +385,6 @@ export function normalizeProjectConfig(
     }
   }
 
-  // Complain about common misspellings
-  if (consumer.has('linter')) {
-    consumer.get('linter').unexpected(`Did you mean <emphasis>lint</emphasis>?`);
-  }
-
   // Need to get this before enforceUsedProperties so it will be flagged
   const _extends = consumer.get('extends');
 
@@ -470,7 +455,9 @@ function extendProjectConfig(
   // Check for recursive config
   for (const path of extendsMeta.configDependencies) {
     if (path.equal(extendsPath)) {
-      throw extendsStrConsumer.unexpected('Recursive config value');
+      throw extendsStrConsumer.unexpected(
+        descriptions.PROJECT_CONFIG.RECURSIVE_CONFIG,
+      );
     }
   }
 

--- a/packages/@romejs/string-markup/format.ts
+++ b/packages/@romejs/string-markup/format.ts
@@ -260,11 +260,19 @@ export function normalizeMarkup(
       return escapeMarkup(text);
     },
     formatTag: (tag, attributes, value) => {
-      // Normalize filename of <filelink target>
-      if (tag === 'filelink') {
-        const {text, filename} = formatFileLink(attributes, value, opts);
-        attributes.set('target', filename);
-        value = text;
+      switch (tag) {
+        case // Normalize filename of <filelink target>
+        'filelink': {
+          const {text, filename} = formatFileLink(attributes, value, opts);
+          attributes.set('target', filename);
+          value = text;
+          break;
+        }
+
+        // We don't technically need to normalize this but it's one less tag to have to support
+        // if other tools need to consume it
+        case 'grammarNumber':
+          return formatGrammarNumber(attributes, value);
       }
 
       let attrStr = Array.from(attributes, ([key, value]) => {

--- a/packages/@romejs/string-markup/parse.ts
+++ b/packages/@romejs/string-markup/parse.ts
@@ -156,9 +156,13 @@ const createStringMarkupParser = createParser(
 
           const end = add(stringValueEnd, 1);
           return {
-            state,
-            token: this.finishValueToken('String', value, end),
-          };
+              state,
+              token: this.finishValueToken(
+                'String',
+                unescapeTextValue(value),
+                end,
+              ),
+            };
         }
 
         if (char === '>') {

--- a/scripts/assert-generated
+++ b/scripts/assert-generated
@@ -17,7 +17,7 @@ require('./runtime-modules/update.cjs');
 require('./ast/update.cjs');
 
 // Autofix them
-execDev(['lint', '--fix']);
+execDev(['lint', '--fix', '--allow-dirty']);
 
 // Check that `git status` is fine
 const out = child_process


### PR DESCRIPTION
This PR adds an error when you try to run `rome ci`, `rome lint --fix`, and `rome lint --review` when you have uncommitted files. In order to bypass the check you can add the flag `--allow-dirty`. This is what the error looks like:

![Screenshot from 2020-04-20 15-33-17](https://user-images.githubusercontent.com/853712/79806047-5b29a400-831c-11ea-836c-c328c3575a73.png)

Explanation is provided in the diagnostic. We should encourage people to commit before running these commands as we might be performing potentially unsafe fixes, and without a significant amount of testing the code formatter or lint rules could produce broken code. Even if we are confident in the stability of the linter I think it's worth encouraging this so we can be heavy on lint fixes.

(Ignore the `--compiler-options-per-file` flag in the screenshot)