### PR TITLE
Add format property to NumericLiteral

### DIFF
--- a/packages/@romejs/js-ast/literals/NumericLiteral.ts
+++ b/packages/@romejs/js-ast/literals/NumericLiteral.ts
@@ -11,6 +11,7 @@ import {createBuilder} from '../utils';
 export type NumericLiteral = JSNodeBase & {
   type: 'NumericLiteral';
   value: number;
+  format?: 'octal' | 'binary' | 'hex';
 };
 
 export const numericLiteral = createBuilder<NumericLiteral>('NumericLiteral', {

--- a/packages/@romejs/js-ast/types/NumericLiteralTypeAnnotation.ts
+++ b/packages/@romejs/js-ast/types/NumericLiteralTypeAnnotation.ts
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {JSNodeBase} from '../index';
+import {JSNodeBase, NumericLiteral} from '../index';
 import {createBuilder} from '../utils';
 
 export type NumericLiteralTypeAnnotation = JSNodeBase & {
   type: 'NumericLiteralTypeAnnotation';
   value: number;
+  format?: NumericLiteral['format'];
 };
 
 export const numericLiteralTypeAnnotation = createBuilder<

--- a/packages/@romejs/js-parser/parser/expression.ts
+++ b/packages/@romejs/js-parser/parser/expression.ts
@@ -7,7 +7,12 @@
 
 import {Position, SourceLocation} from '@romejs/parser-core';
 import {JSParser, OpeningContext} from '../parser';
-import {RegExpTokenValue, readRegexp, finishToken} from '../tokenizer/index';
+import {
+  RegExpTokenValue,
+  readRegexp,
+  finishToken,
+  NumberTokenValue,
+} from '../tokenizer/index';
 import * as charCodes from '@romejs/string-charcodes';
 import {types as tt} from '../tokenizer/types';
 import {
@@ -3425,10 +3430,16 @@ function parseBigIntLiteral(parser: JSParser): BigIntLiteral {
 
 export function parseNumericLiteral(parser: JSParser): NumericLiteral {
   const start = parser.getPosition();
-  const value = Number(parser.state.tokenValue);
+  const {tokenValue} = parser.state;
+  if (!(tokenValue instanceof NumberTokenValue)) {
+    throw new Error('Expected NumberTokenValue');
+  }
+
+  const {value, format} = tokenValue;
   parser.next();
   return parser.finishNode(start, {
     type: 'NumericLiteral',
+    format,
     value,
   });
 }

--- a/packages/@romejs/js-parser/parser/type-systems.ts
+++ b/packages/@romejs/js-parser/parser/type-systems.ts
@@ -127,6 +127,7 @@ export function parseTypeLiteralAnnotation(
         return parser.finishNode(start, {
           type: 'NumericLiteralTypeAnnotation',
           value: -value,
+          format,
         });
       } else {
         parser.addDiagnostic({

--- a/packages/@romejs/js-parser/parser/type-systems.ts
+++ b/packages/@romejs/js-parser/parser/type-systems.ts
@@ -55,6 +55,7 @@ import {
   toTargetAssignmentPattern,
 } from './index';
 import {descriptions} from '@romejs/diagnostics';
+import {NumberTokenValue} from '../tokenizer';
 
 export function isTypeSystemEnabled(parser: JSParser): boolean {
   return parser.isSyntaxEnabled('flow') || parser.isSyntaxEnabled('ts');
@@ -76,11 +77,17 @@ export function parseTypeLiteralAnnotation(
     }
 
     case tt.num: {
-      const value = Number(parser.state.tokenValue);
+      const {tokenValue} = parser.state;
+      if (!(tokenValue instanceof NumberTokenValue)) {
+        throw new Error('Expected NumberTokenValue');
+      }
+
+      const {value, format} = tokenValue;
       parser.next();
       return parser.finishNode(start, {
         type: 'NumericLiteralTypeAnnotation',
         value,
+        format,
       });
     }
 
@@ -95,7 +102,8 @@ export function parseTypeLiteralAnnotation(
     }
 
     case tt.plusMin: {
-      if (parser.state.tokenValue === '-') {
+      const {tokenValue} = parser.state;
+      if (tokenValue === '-') {
         parser.next();
 
         if (!parser.match(tt.num)) {
@@ -109,7 +117,12 @@ export function parseTypeLiteralAnnotation(
           });
         }
 
-        const value = Number(parser.state.tokenValue);
+        const {tokenValue} = parser.state;
+        if (!(tokenValue instanceof NumberTokenValue)) {
+          throw new Error('Expected NumberTokenValue');
+        }
+
+        const {value, format} = tokenValue;
         parser.next();
         return parser.finishNode(start, {
           type: 'NumericLiteralTypeAnnotation',

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/call-expression-function-argument/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/call-expression-function-argument/output.txt
@@ -224,6 +224,7 @@ Program {
                         }
                         init: NumericLiteral {
                           value: 1
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/create-parenthesized-expressions/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/create-parenthesized-expressions/output.txt
@@ -110,6 +110,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'
@@ -143,6 +144,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'
@@ -175,6 +177,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3
+        format: undefined
         leadingComments: Array ['2']
         loc: Object {
           filename: 'input.js'
@@ -207,6 +210,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 4
+        format: undefined
         leadingComments: Array ['3']
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/surrounding-throw-comments/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/surrounding-throw-comments/output.txt
@@ -146,6 +146,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 55
+              format: undefined
               leadingComments: undefined
               loc: Object {
                 filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-fallthrough-comment-in-function/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-fallthrough-comment-in-function/output.txt
@@ -211,6 +211,7 @@ Program {
                 }
                 test: NumericLiteral {
                   value: 1
+                  format: undefined
                   leadingComments: Array ['0']
                   loc: Object {
                     filename: 'input.js'
@@ -243,6 +244,7 @@ Program {
                 }
                 test: NumericLiteral {
                   value: 2
+                  format: undefined
                   leadingComments: Array ['1']
                   loc: Object {
                     filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-fallthrough-comment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-fallthrough-comment/output.txt
@@ -107,6 +107,7 @@ Program {
           }
           test: NumericLiteral {
             value: 1
+            format: undefined
             leadingComments: Array ['0']
             loc: Object {
               filename: 'input.js'
@@ -139,6 +140,7 @@ Program {
           }
           test: NumericLiteral {
             value: 2
+            format: undefined
             leadingComments: Array ['1']
             loc: Object {
               filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-function-call-no-semicolon-no-default/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-function-call-no-semicolon-no-default/output.txt
@@ -89,6 +89,7 @@ Program {
           }
           test: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-function-call-no-semicolon/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-function-call-no-semicolon/output.txt
@@ -89,6 +89,7 @@ Program {
           }
           test: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment-in-function/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment-in-function/output.txt
@@ -192,6 +192,7 @@ Program {
                 }
                 test: NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -242,6 +243,7 @@ Program {
                 }
                 test: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment-in-nested-functions/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment-in-nested-functions/output.txt
@@ -574,6 +574,7 @@ Program {
                                         }
                                         right: NumericLiteral {
                                           value: 1
+                                          format: undefined
                                           loc: Object {
                                             filename: 'input.js'
                                             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/comments/basic/switch-no-default-comment/output.txt
@@ -89,6 +89,7 @@ Program {
           }
           test: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/categorized/01-regex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/categorized/01-regex/output.txt
@@ -131,6 +131,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/categorized/02-regex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/categorized/02-regex/output.txt
@@ -85,6 +85,7 @@ Program {
           }
           right: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/categorized/03-regex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/categorized/03-regex/output.txt
@@ -154,6 +154,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 42
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/categorized/06-regex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/categorized/06-regex/output.txt
@@ -85,6 +85,7 @@ Program {
           }
           right: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/categorized/startline-specified/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/categorized/startline-specified/output.txt
@@ -70,6 +70,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -134,6 +135,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/regression/non-octal-float/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/regression/non-octal-float/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9.5
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/10/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/10/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/11/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/11/output.txt
@@ -87,6 +87,7 @@ Program {
             undefined
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/12/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -117,6 +119,7 @@ Program {
             }
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/124/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/124/output.txt
@@ -115,6 +115,7 @@ Program {
           property: ComputedMemberProperty {
             value: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/125/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/125/output.txt
@@ -115,6 +115,7 @@ Program {
           arguments: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/126/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/126/output.txt
@@ -99,6 +99,7 @@ Program {
           arguments: Array [
             NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -115,6 +116,7 @@ Program {
             }
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -131,6 +133,7 @@ Program {
             }
             NumericLiteral {
               value: 77
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -224,6 +227,7 @@ Program {
               arguments: Array [
                 NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/127/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/127/output.txt
@@ -54,6 +54,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 2_014
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/13/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/13/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -118,6 +120,7 @@ Program {
             undefined
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/197/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/197/output.txt
@@ -51,8 +51,25 @@ Program {
             line: 1
           }
         }
+        test: ReferenceIdentifier {
+          name: 'y'
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 1
+              index: 1
+              line: 1
+            }
+            start: Object {
+              column: 0
+              index: 0
+              line: 1
+            }
+          }
+        }
         alternate: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -69,6 +86,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -79,22 +97,6 @@ Program {
             start: Object {
               column: 4
               index: 4
-              line: 1
-            }
-          }
-        }
-        test: ReferenceIdentifier {
-          name: 'y'
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 1
-              index: 1
-              line: 1
-            }
-            start: Object {
-              column: 0
-              index: 0
               line: 1
             }
           }

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/198/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/198/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         alternate: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -69,6 +70,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/199/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/199/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/200/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/200/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/201/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/201/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/202/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/202/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/203/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/203/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/204/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/204/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/205/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/205/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/206/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/206/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/207/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/207/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/208/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/208/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/209/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/209/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/210/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/210/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/211/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/211/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/212/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/212/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/218/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/218/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/219/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/219/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/22/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/22/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/220/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/220/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -179,6 +181,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1_977
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/23/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/23/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/230/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/230/output.txt
@@ -116,6 +116,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/234/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/234/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/237/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/237/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/24/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/24/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/240/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/240/output.txt
@@ -87,6 +87,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/241/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/241/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/242/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/242/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -149,6 +150,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/243/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/243/output.txt
@@ -86,6 +86,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -134,6 +135,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/244/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/244/output.txt
@@ -118,6 +118,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -166,6 +167,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/245/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/245/output.txt
@@ -103,6 +103,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -151,6 +152,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/25/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/25/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/26/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/26/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/269/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/269/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/27/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/27/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/270/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/270/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/28/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/28/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -181,6 +182,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/3/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/303/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/303/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 14
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -148,6 +149,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/319/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/319/output.txt
@@ -54,6 +54,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 10
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           object: NumericLiteral {
             value: 123
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/320/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/320/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -70,6 +71,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/323/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/323/output.txt
@@ -69,6 +69,7 @@ Program {
         }
         expression: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -131,6 +132,7 @@ Program {
         }
         expression: NumericLiteral {
           value: 20
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/324/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/324/output.txt
@@ -40,6 +40,7 @@ Program {
       }
       test: NumericLiteral {
         value: 1
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/327/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/327/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/329/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/329/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/333/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/333/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       test: NumericLiteral {
         value: 1
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/334/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/334/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -70,6 +71,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/335/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/335/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -164,6 +165,7 @@ Program {
                   elements: Array [
                     NumericLiteral {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/336/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/336/output.txt
@@ -70,6 +70,7 @@ Program {
             elements: Array [
               NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/337/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/337/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/338/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/338/output.txt
@@ -56,6 +56,7 @@ Program {
             key: StaticPropertyKey {
               value: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -118,6 +119,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/339/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/339/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/343/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/343/output.txt
@@ -104,6 +104,7 @@ Program {
           }
           right: NumericLiteral {
             value: 10
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/355/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/355/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/356/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/356/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 18
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/36/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/36/output.txt
@@ -88,6 +88,7 @@ Program {
               key: StaticPropertyKey {
                 value: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/43/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/43/output.txt
@@ -88,6 +88,7 @@ Program {
               key: StaticPropertyKey {
                 value: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/44/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/44/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/45/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/45/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 43
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/46/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/46/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/47/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/47/output.txt
@@ -78,6 +78,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         trailingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/48/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/48/output.txt
@@ -78,6 +78,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         trailingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/49/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/49/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/50/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/50/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/51/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/51/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/52/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/52/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/527/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/527/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/528/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/528/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/529/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/529/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -179,6 +181,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1_977
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/53/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/53/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/530/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/530/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/531/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/531/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -149,6 +150,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/533/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/533/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/534/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/534/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/535/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/535/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -179,6 +181,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1_977
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/537/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/537/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/54/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/54/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/540/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/540/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/543/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/543/output.txt
@@ -193,6 +193,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 64
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/55/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/55/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         trailingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/551/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/551/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 73
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/553/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/553/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 25_257_156_155
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/56/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/56/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/59/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/59/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/6/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/62/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/62/output.txt
@@ -58,6 +58,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/63/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/63/output.txt
@@ -78,6 +78,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         leadingComments: undefined
         loc: Object {
           filename: 'input.js'

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/65/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/65/output.txt
@@ -88,6 +88,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/66/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/66/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/67/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/67/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/68/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/68/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 5
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/69/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/69/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/70/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/70/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0.14
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/71/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/71/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3.14159
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/72/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/72/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 6.02214179e+23
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/73/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/73/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1.49241783e-10
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/74/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/74/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/75/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/75/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/76/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/76/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2_748
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/77/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/77/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3_567
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/78/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/78/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 26
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/79/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/79/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 16
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/80/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/80/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 256
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/81/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/81/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 4
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/82/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/82/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/83/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/83/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/84/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/84/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/9/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/9/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/array-rest-spread/with-object/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/array-rest-spread/with-object/output.txt
@@ -198,6 +198,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -214,6 +215,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -230,6 +232,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/for-in/nonstrict-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/for-in/nonstrict-initializer/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -165,6 +166,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -440,6 +442,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -573,6 +576,7 @@ Program {
                 }
                 value: NumericLiteral {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -636,6 +640,7 @@ Program {
                 }
                 value: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -699,6 +704,7 @@ Program {
                 }
                 value: NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-1/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-1/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-2/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-5/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-5/output.txt
@@ -40,6 +40,7 @@ Program {
       }
       test: NumericLiteral {
         value: 1
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-6/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       test: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-7/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-as-identifier-7/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       test: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-with-linebreak-arr-dstrk/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-with-linebreak-arr-dstrk/output.txt
@@ -135,6 +135,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/let/let-with-linebreak-obj-dstrk/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/let/let-with-linebreak-obj-dstrk/output.txt
@@ -198,6 +198,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/modules/duplicate-named-export-builtin/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/modules/duplicate-named-export-builtin/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/10/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/10/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/11/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/11/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/12/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/13/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/13/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/14/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/14/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/141/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/141/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/142/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/142/output.txt
@@ -119,6 +119,7 @@ Program {
             }
             value: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/144/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/144/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -150,6 +151,7 @@ Program {
             }
             value: NumericLiteral {
               value: 20
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/15/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/15/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/152/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/152/output.txt
@@ -124,6 +124,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/153/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/153/output.txt
@@ -157,6 +157,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 10
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/154/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/154/output.txt
@@ -187,6 +187,7 @@ Program {
                       }
                       value: NumericLiteral {
                         value: 10
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/155/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/155/output.txt
@@ -204,6 +204,7 @@ Program {
                           }
                           value: NumericLiteral {
                             value: 10
+                            format: undefined
                             loc: Object {
                               filename: 'input.js'
                               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/156/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/156/output.txt
@@ -203,6 +203,7 @@ Program {
                         }
                         value: NumericLiteral {
                           value: 10
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/157/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/157/output.txt
@@ -248,6 +248,7 @@ Program {
                           }
                           value: NumericLiteral {
                             value: 10
+                            format: undefined
                             loc: Object {
                               filename: 'input.js'
                               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/158/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/158/output.txt
@@ -104,86 +104,6 @@ Program {
                   line: 1
                 }
               }
-              right: ObjectExpression {
-                loc: Object {
-                  filename: 'input.js'
-                  end: Object {
-                    column: 15
-                    index: 15
-                    line: 1
-                  }
-                  start: Object {
-                    column: 8
-                    index: 8
-                    line: 1
-                  }
-                }
-                properties: Array [
-                  ObjectProperty {
-                    key: StaticPropertyKey {
-                      value: Identifier {
-                        name: 'x'
-                        loc: Object {
-                          filename: 'input.js'
-                          end: Object {
-                            column: 10
-                            index: 10
-                            line: 1
-                          }
-                          start: Object {
-                            column: 9
-                            index: 9
-                            line: 1
-                          }
-                        }
-                      }
-                      variance: undefined
-                      loc: Object {
-                        filename: 'input.js'
-                        end: Object {
-                          column: 10
-                          index: 10
-                          line: 1
-                        }
-                        start: Object {
-                          column: 9
-                          index: 9
-                          line: 1
-                        }
-                      }
-                    }
-                    value: NumericLiteral {
-                      value: 10
-                      loc: Object {
-                        filename: 'input.js'
-                        end: Object {
-                          column: 14
-                          index: 14
-                          line: 1
-                        }
-                        start: Object {
-                          column: 12
-                          index: 12
-                          line: 1
-                        }
-                      }
-                    }
-                    loc: Object {
-                      filename: 'input.js'
-                      end: Object {
-                        column: 14
-                        index: 14
-                        line: 1
-                      }
-                      start: Object {
-                        column: 9
-                        index: 9
-                        line: 1
-                      }
-                    }
-                  }
-                ]
-              }
               left: BindingObjectPattern {
                 rest: undefined
                 loc: Object {
@@ -259,6 +179,87 @@ Program {
                       start: Object {
                         column: 3
                         index: 3
+                        line: 1
+                      }
+                    }
+                  }
+                ]
+              }
+              right: ObjectExpression {
+                loc: Object {
+                  filename: 'input.js'
+                  end: Object {
+                    column: 15
+                    index: 15
+                    line: 1
+                  }
+                  start: Object {
+                    column: 8
+                    index: 8
+                    line: 1
+                  }
+                }
+                properties: Array [
+                  ObjectProperty {
+                    key: StaticPropertyKey {
+                      value: Identifier {
+                        name: 'x'
+                        loc: Object {
+                          filename: 'input.js'
+                          end: Object {
+                            column: 10
+                            index: 10
+                            line: 1
+                          }
+                          start: Object {
+                            column: 9
+                            index: 9
+                            line: 1
+                          }
+                        }
+                      }
+                      variance: undefined
+                      loc: Object {
+                        filename: 'input.js'
+                        end: Object {
+                          column: 10
+                          index: 10
+                          line: 1
+                        }
+                        start: Object {
+                          column: 9
+                          index: 9
+                          line: 1
+                        }
+                      }
+                    }
+                    value: NumericLiteral {
+                      value: 10
+                      format: undefined
+                      loc: Object {
+                        filename: 'input.js'
+                        end: Object {
+                          column: 14
+                          index: 14
+                          line: 1
+                        }
+                        start: Object {
+                          column: 12
+                          index: 12
+                          line: 1
+                        }
+                      }
+                    }
+                    loc: Object {
+                      filename: 'input.js'
+                      end: Object {
+                        column: 14
+                        index: 14
+                        line: 1
+                      }
+                      start: Object {
+                        column: 9
+                        index: 9
                         line: 1
                       }
                     }

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/159/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/159/output.txt
@@ -139,6 +139,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/16/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/16/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/160/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/160/output.txt
@@ -109,6 +109,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/161/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/161/output.txt
@@ -187,6 +187,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/162/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/162/output.txt
@@ -186,6 +186,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/17/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/17/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/26/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/26/output.txt
@@ -206,6 +206,7 @@ Program {
                       }
                       value: NumericLiteral {
                         value: 10
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {
@@ -376,6 +377,7 @@ Program {
                       }
                       argument: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/27/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/27/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -147,6 +148,7 @@ Program {
                     }
                     init: NumericLiteral {
                       value: 42
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/3/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/300/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/300/output.txt
@@ -142,6 +142,7 @@ Program {
             }
             right: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/307/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/307/output.txt
@@ -78,6 +78,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/308/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/308/output.txt
@@ -78,6 +78,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/309/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/309/output.txt
@@ -190,6 +190,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/310/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/310/output.txt
@@ -142,6 +142,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/317/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/317/output.txt
@@ -107,6 +107,7 @@ Program {
             property: ComputedMemberProperty {
               value: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/318/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/318/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/319/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/319/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 10
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/32/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/32/output.txt
@@ -120,6 +120,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/320/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/320/output.txt
@@ -135,6 +135,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/322/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/322/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/33/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/33/output.txt
@@ -138,6 +138,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/34/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/34/output.txt
@@ -150,6 +150,7 @@ Program {
                 }
                 expression: NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/35/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/35/output.txt
@@ -83,6 +83,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/350/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/350/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -150,6 +151,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/351/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/351/output.txt
@@ -155,6 +155,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -208,6 +209,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/352/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/352/output.txt
@@ -155,6 +155,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -208,6 +209,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/36/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/36/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/380/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/380/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/381/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/381/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/382/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/382/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/39/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/39/output.txt
@@ -153,6 +153,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/4/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/40/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/40/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/41/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/41/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/42/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/42/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: 'octal'
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/43/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/43/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/44/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/44/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -121,6 +122,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/45/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/45/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -137,6 +138,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/47/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/47/output.txt
@@ -104,6 +104,7 @@ Program {
           }
           body: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/5/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/5/output.txt
@@ -126,6 +126,7 @@ Program {
             }
             expression: NumericLiteral {
               value: 0
+              format: 'octal'
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/6/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/7/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/7/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/79/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/79/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       declaration: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/8/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/8/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/9/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/uncategorised/9/output.txt
@@ -126,6 +126,7 @@ Program {
             }
             expression: NumericLiteral {
               value: 0
+              format: 'octal'
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/input-not-followed-by-regex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/input-not-followed-by-regex/output.txt
@@ -176,6 +176,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-as-identifier/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-as-identifier/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-in-arrow-scope-is-multiplication/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-in-arrow-scope-is-multiplication/output.txt
@@ -121,6 +121,7 @@ Program {
           }
           right: NumericLiteral {
             value: 10
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-in-global-scope-is-multiplication/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-in-global-scope-is-multiplication/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-inside-plain-function/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-star-inside-plain-function/output.txt
@@ -139,6 +139,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-yield/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2015/yield/yield-yield/output.txt
@@ -138,6 +138,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 10
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/1/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/1/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -70,6 +71,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/2/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           left: NumericLiteral {
             value: 5
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -86,6 +87,7 @@ Program {
           }
           right: NumericLiteral {
             value: 6
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/3/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/4/output.txt
@@ -100,6 +100,7 @@ Program {
               }
               left: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -116,6 +117,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/5/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/5/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 3
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/6/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 3
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/7/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/7/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -117,6 +119,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/8/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/8/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -117,6 +119,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/9/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2016/exponentiation-operator/9/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 6
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -86,6 +87,7 @@ Program {
           }
           argument: NumericLiteral {
             value: 5
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/15/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/15/output.txt
@@ -133,6 +133,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/19/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/19/output.txt
@@ -117,6 +117,7 @@ Program {
             arguments: Array [
               NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -133,6 +134,7 @@ Program {
               }
               NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/21/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/21/output.txt
@@ -204,6 +204,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/await-inside-arguments-of-async-function-call/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/await-inside-arguments-of-async-function-call/output.txt
@@ -185,6 +185,7 @@ Program {
                     }
                     argument: NumericLiteral {
                       value: 2
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/await-inside-parenthesized-assign/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/async-functions/await-inside-parenthesized-assign/output.txt
@@ -154,6 +154,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/trailing-function-commas/1/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/trailing-function-commas/1/output.txt
@@ -102,6 +102,7 @@ Program {
           }
           NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/es2017/trailing-function-commas/4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/es2017/trailing-function-commas/4/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/automatic-semicolon-insertion/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/automatic-semicolon-insertion/migrated_0003/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 14
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -148,6 +149,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0000/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0001/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-const/migrated_0002/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 14
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -148,6 +149,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -195,6 +197,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 1_977
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-function/migrated_0014/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-function/migrated_0014/output.txt
@@ -140,6 +140,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-let/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-let/migrated_0002/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/declaration-let/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/declaration-let/migrated_0003/output.txt
@@ -101,6 +101,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 14
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -148,6 +149,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -195,6 +197,7 @@ Program {
                 }
                 init: NumericLiteral {
                   value: 1_977
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-01/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-01/output.txt
@@ -68,6 +68,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-02/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-02/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-03/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-03/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-empty/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/array-binding-pattern-empty/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/elision/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-binding-pattern/elision/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/elision/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/elision/output.txt
@@ -120,6 +120,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/empty-pattern-var/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/empty-pattern-var/output.txt
@@ -86,6 +86,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/hole/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/hole/output.txt
@@ -154,6 +154,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/nested-pattern/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/nested-pattern/output.txt
@@ -121,6 +121,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/patterned-catch/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/patterned-catch/output.txt
@@ -329,6 +329,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -423,6 +424,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/rest/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/rest/output.txt
@@ -118,6 +118,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/tailing-hold/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/tailing-hold/output.txt
@@ -121,6 +121,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-default-catch-param/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-default-catch-param/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-default-fn/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-default-fn/output.txt
@@ -142,6 +142,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-object-pattern/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-array-pattern/with-object-pattern/output.txt
@@ -185,6 +185,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/arrow-with-multiple-arg-and-rest/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/arrow-with-multiple-arg-and-rest/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/arrow-with-only-rest/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/arrow-with-only-rest/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0004/output.txt
@@ -120,6 +120,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0005/output.txt
@@ -138,6 +138,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0006/output.txt
@@ -150,6 +150,7 @@ Program {
                 }
                 expression: NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0007/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0007/output.txt
@@ -83,6 +83,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0008/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0008/output.txt
@@ -153,6 +153,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0009/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0009/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0010/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0010/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0011/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0011/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: 'octal'
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0012/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0012/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0013/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0013/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -121,6 +122,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0014/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0014/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -137,6 +138,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/migrated_0016/output.txt
@@ -104,6 +104,7 @@ Program {
           }
           body: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-01/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-01/output.txt
@@ -524,6 +524,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-empty/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-empty/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-invalid-rest-in-object-pattern/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-invalid-rest-in-object-pattern/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.txt
@@ -77,6 +77,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0000/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0001/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0002/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0003/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0004/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-binary-integer-literal/migrated_0005/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0001/output.txt
@@ -73,6 +73,7 @@ Program {
         }
         superClass: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0016/output.txt
@@ -133,6 +133,7 @@ Program {
                 }
                 superClass: NumericLiteral {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0024/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0024/output.txt
@@ -72,6 +72,7 @@ Program {
           }
           superClass: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0025/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-class/migrated_0025/output.txt
@@ -87,6 +87,7 @@ Program {
           }
           superClass: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0000/output.txt
@@ -139,6 +139,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0001/output.txt
@@ -109,6 +109,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-default-parameter-value/migrated_0002/output.txt
@@ -187,6 +187,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/dup-assignment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/dup-assignment/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/elision/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/elision/output.txt
@@ -52,22 +52,6 @@ Program {
             line: 1
           }
         }
-        right: NumericLiteral {
-          value: 0
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 6
-              index: 6
-              line: 1
-            }
-            start: Object {
-              column: 5
-              index: 5
-              line: 1
-            }
-          }
-        }
         left: AssignmentArrayPattern {
           elements: Array []
           rest: undefined
@@ -81,6 +65,23 @@ Program {
             start: Object {
               column: 0
               index: 0
+              line: 1
+            }
+          }
+        }
+        right: NumericLiteral {
+          value: 0
+          format: undefined
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 6
+              index: 6
+              line: 1
+            }
+            start: Object {
+              column: 5
+              index: 5
               line: 1
             }
           }

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/member-expr-in-rest/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/member-expr-in-rest/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -116,6 +117,7 @@ Program {
             property: ComputedMemberProperty {
               value: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-assignment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-assignment/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -133,6 +134,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -244,6 +246,7 @@ Program {
                   property: ComputedMemberProperty {
                     value: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.txt
@@ -222,6 +222,7 @@ Program {
             }
             right: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/simple-assignment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-array-pattern/simple-assignment/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/empty-object-pattern-assignment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/empty-object-pattern-assignment/output.txt
@@ -52,22 +52,6 @@ Program {
             line: 1
           }
         }
-        right: NumericLiteral {
-          value: 0
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 7
-              index: 7
-              line: 1
-            }
-            start: Object {
-              column: 6
-              index: 6
-              line: 1
-            }
-          }
-        }
         left: AssignmentObjectPattern {
           properties: Array []
           rest: undefined
@@ -81,6 +65,23 @@ Program {
             start: Object {
               column: 1
               index: 1
+              line: 1
+            }
+          }
+        }
+        right: NumericLiteral {
+          value: 0
+          format: undefined
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 7
+              index: 7
+              line: 1
+            }
+            start: Object {
+              column: 6
+              index: 6
               line: 1
             }
           }

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.txt
@@ -78,6 +78,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -460,6 +461,7 @@ Program {
                                                                                             property: ComputedMemberProperty {
                                                                                               value: NumericLiteral {
                                                                                                 value: 0
+                                                                                                format: undefined
                                                                                                 loc: Object {
                                                                                                   filename: 'input.js'
                                                                                                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/object-pattern-assignment/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-destructuring-assignment-object-pattern/object-pattern-assignment/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-const-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-const-number/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-expression/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-expression/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -70,6 +71,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-number/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       declaration: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-object/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-default-object/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-let-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-let-number/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-var-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-export-declaration/export-var-number/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-declaration-with-yield-delegate/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-declaration-with-yield-delegate/output.txt
@@ -124,6 +124,7 @@ Program {
               }
               argument: NumericLiteral {
                 value: 3
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-declaration-with-yield/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-declaration-with-yield/output.txt
@@ -124,6 +124,7 @@ Program {
               }
               argument: NumericLiteral {
                 value: 3
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-expression-with-yield/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-expression-with-yield/output.txt
@@ -123,6 +123,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-delegate/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-delegate/output.txt
@@ -170,6 +170,7 @@ Program {
                     }
                     argument: NumericLiteral {
                       value: 3
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-expression/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-expression/output.txt
@@ -170,6 +170,7 @@ Program {
                     }
                     argument: NumericLiteral {
                       value: 3
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-line-terminator/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-generator/generator-method-with-yield-line-terminator/output.txt
@@ -187,6 +187,7 @@ Program {
                   }
                   expression: NumericLiteral {
                     value: 3
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-identifier/module_await/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-identifier/module_await/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-lexical-declaration/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-lexical-declaration/migrated_0000/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -147,6 +148,7 @@ Program {
                     }
                     init: NumericLiteral {
                       value: 42
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/elision/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/elision/output.txt
@@ -150,6 +150,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-for-lex/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-for-lex/output.txt
@@ -54,6 +54,7 @@ Program {
       }
       right: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-lexical/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-lexical/output.txt
@@ -86,6 +86,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-var/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/empty-var/output.txt
@@ -86,6 +86,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/nested/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/nested/output.txt
@@ -151,6 +151,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/properties/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-object-pattern/properties/output.txt
@@ -198,6 +198,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -355,6 +356,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -499,6 +501,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0000/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0001/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0002/output.txt
@@ -126,6 +126,7 @@ Program {
             }
             expression: NumericLiteral {
               value: 0
+              format: 'octal'
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0003/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0004/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0005/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-octal-integer-literal/migrated_0006/output.txt
@@ -126,6 +126,7 @@ Program {
             }
             expression: NumericLiteral {
               value: 0
+              format: 'octal'
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-spread-element/call-spread-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-spread-element/call-spread-number/output.txt
@@ -84,6 +84,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 0.5
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-spread-element/new-spread-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-spread-element/new-spread-number/output.txt
@@ -86,6 +86,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 0.5
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-super-property/super_computed/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-super-property/super_computed/output.txt
@@ -246,6 +246,7 @@ Program {
                     property: ComputedMemberProperty {
                       value: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-yield/yield-arrow-parameter-name/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-yield/yield-arrow-parameter-name/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/es2015-yield/yield-lexical-declaration/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/es2015-yield/yield-lexical-declaration/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-additive/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-additive/migrated_0002/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0000/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0001/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0002/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0003/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0004/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0005/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0006/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0007/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0007/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0008/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0008/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0009/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0009/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0010/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0010/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0011/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0011/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0012/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0012/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0013/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-assignment/migrated_0013/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0000/output.txt
@@ -51,8 +51,25 @@ Program {
             line: 1
           }
         }
+        test: ReferenceIdentifier {
+          name: 'y'
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 1
+              index: 1
+              line: 1
+            }
+            start: Object {
+              column: 0
+              index: 0
+              line: 1
+            }
+          }
+        }
         alternate: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -69,6 +86,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -79,22 +97,6 @@ Program {
             start: Object {
               column: 4
               index: 4
-              line: 1
-            }
-          }
-        }
-        test: ReferenceIdentifier {
-          name: 'y'
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 1
-              index: 1
-              line: 1
-            }
-            start: Object {
-              column: 0
-              index: 0
               line: 1
             }
           }

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0001/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         alternate: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -69,6 +70,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-conditional/migrated_0002/output.txt
@@ -84,6 +84,7 @@ Program {
           }
           alternate: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -100,6 +101,7 @@ Program {
           }
           consequent: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -116,6 +118,7 @@ Program {
           }
           test: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-grouping/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-grouping/migrated_0000/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-grouping/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-grouping/migrated_0001/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 6
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 4
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 5
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0015/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0015/output.txt
@@ -115,6 +115,7 @@ Program {
           property: ComputedMemberProperty {
             value: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0016/output.txt
@@ -115,6 +115,7 @@ Program {
           arguments: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0017/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0017/output.txt
@@ -99,6 +99,7 @@ Program {
           arguments: Array [
             NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -115,6 +116,7 @@ Program {
             }
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -131,6 +133,7 @@ Program {
             }
             NumericLiteral {
               value: 77
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -224,6 +227,7 @@ Program {
               arguments: Array [
                 NumericLiteral {
                   value: 42
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0018/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-left-hand-side/migrated_0018/output.txt
@@ -54,6 +54,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 2_014
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0002/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0003/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0004/output.txt
@@ -87,6 +87,7 @@ Program {
             undefined
             NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0005/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -117,6 +119,7 @@ Program {
             }
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-array/migrated_0006/output.txt
@@ -85,6 +85,7 @@ Program {
           elements: Array [
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -118,6 +120,7 @@ Program {
             undefined
             NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0000/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0000/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0001/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0002/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0003/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 5
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0004/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0.14
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0005/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3.14159
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0006/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 6.02214179e+23
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0007/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0007/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 1.49241783e-10
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0008/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0008/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0009/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0009/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0010/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0010/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0011/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0011/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0012/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0012/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2_748
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0013/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0013/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3_567
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0014/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0014/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 26
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0015/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0015/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 16
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0016/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 256
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0017/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0017/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 4
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0018/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0018/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 2
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0019/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0019/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0020/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0020/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 10
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0021/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0021/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 8
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0022/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0022/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 8
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0023/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0023/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0024/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-literal-numeric/migrated_0024/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9.5
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0002/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0003/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0004/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0005/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0005/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0006/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0006/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0007/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0007/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0008/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0008/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -181,6 +182,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0016/output.txt
@@ -88,6 +88,7 @@ Program {
               key: StaticPropertyKey {
                 value: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0023/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0023/output.txt
@@ -88,6 +88,7 @@ Program {
               key: StaticPropertyKey {
                 value: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0024/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0024/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 42
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0025/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0025/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 43
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0026/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0026/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0027/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0027/output.txt
@@ -118,6 +118,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 2
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0029/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0029/output.txt
@@ -176,6 +176,7 @@ Program {
             }
             value: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0030/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0030/output.txt
@@ -135,6 +135,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -198,6 +199,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0032/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0032/output.txt
@@ -150,6 +150,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 42
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0033/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0033/output.txt
@@ -273,6 +273,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 42
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0036/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0036/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -150,6 +151,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0037/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0037/output.txt
@@ -87,6 +87,7 @@ Program {
             }
             value: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0038/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-object/migrated_0038/output.txt
@@ -155,6 +155,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-other/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-other/migrated_0002/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 42
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-other/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/expression-primary-other/migrated_0003/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -85,6 +86,7 @@ Program {
           }
           left: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -101,6 +103,7 @@ Program {
           }
           right: NumericLiteral {
             value: 2
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-if/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-if/migrated_0002/output.txt
@@ -116,6 +116,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0002/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0007/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0007/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 10
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0010/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0010/output.txt
@@ -87,6 +87,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0011/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0011/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0012/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0012/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0013/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0013/output.txt
@@ -102,6 +102,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -149,6 +150,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0014/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0014/output.txt
@@ -86,6 +86,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -134,6 +135,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0015/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0015/output.txt
@@ -118,6 +118,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -166,6 +167,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0016/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0016/output.txt
@@ -103,6 +103,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -151,6 +152,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0025/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-iteration/migrated_0025/output.txt
@@ -85,6 +85,7 @@ Program {
         property: ComputedMemberProperty {
           value: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-switch/migrated_0001/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-switch/migrated_0001/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-switch/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-switch/migrated_0002/output.txt
@@ -70,6 +70,7 @@ Program {
           }
           test: NumericLiteral {
             value: 42
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0002/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0002/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0003/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0003/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 42
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0004/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/statement-variable/migrated_0004/output.txt
@@ -85,6 +85,7 @@ Program {
             }
             init: NumericLiteral {
               value: 14
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -132,6 +133,7 @@ Program {
             }
             init: NumericLiteral {
               value: 3
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -179,6 +181,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1_977
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-private-methods/combined/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-private-methods/combined/output.txt
@@ -107,6 +107,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -376,6 +377,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -560,6 +562,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 9_999
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/inline/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/inline/output.txt
@@ -306,6 +306,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -395,6 +396,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/nested/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/nested/output.txt
@@ -106,6 +106,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -195,6 +196,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -362,6 +364,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -426,6 +429,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -930,6 +934,7 @@ Program {
                             }
                             value: NumericLiteral {
                               value: 1
+                              format: undefined
                               loc: Object {
                                 filename: 'input.js'
                                 end: Object {
@@ -1019,6 +1024,7 @@ Program {
                             }
                             value: NumericLiteral {
                               value: 2
+                              format: undefined
                               loc: Object {
                                 filename: 'input.js'
                                 end: Object {
@@ -1186,6 +1192,7 @@ Program {
                                   }
                                   right: NumericLiteral {
                                     value: 0
+                                    format: undefined
                                     loc: Object {
                                       filename: 'input.js'
                                       end: Object {
@@ -1250,6 +1257,7 @@ Program {
                                   }
                                   right: NumericLiteral {
                                     value: 0
+                                    format: undefined
                                     loc: Object {
                                       filename: 'input.js'
                                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/pbn-success/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/pbn-success/output.txt
@@ -106,6 +106,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -195,6 +196,7 @@ Program {
             }
             value: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -362,6 +364,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -426,6 +429,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/static/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-private-properties/static/output.txt
@@ -180,6 +180,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/arguments-in-key/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/arguments-in-key/output.txt
@@ -177,6 +177,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 2
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/edge-cases/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/edge-cases/output.txt
@@ -1917,6 +1917,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/inline/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/inline/output.txt
@@ -311,6 +311,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -402,6 +403,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/new-target-with-flow/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/new-target-with-flow/output.txt
@@ -275,6 +275,7 @@ Program {
                 }
                 left: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -984,6 +985,7 @@ Program {
                 }
                 left: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/new-target/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/class-properties/new-target/output.txt
@@ -275,6 +275,7 @@ Program {
                 }
                 left: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -984,6 +985,7 @@ Program {
                 }
                 left: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/do-expressions/scoping-variable/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/do-expressions/scoping-variable/output.txt
@@ -240,6 +240,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/nullish-coalescing-operator/expression/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/nullish-coalescing-operator/expression/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-0/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-0/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 11
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-1/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-1/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 11.11
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-10/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-10/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 171
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-11/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-11/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 448_585_456
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-12/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-13/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-13/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 3
+        format: 'binary'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-14/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-14/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-15/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-15/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 9
+        format: 'octal'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-2/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 11.01
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-3/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 11.01
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-4/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0.11
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-5/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-5/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 17
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-6/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 161
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-7/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-7/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 161
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-8/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-8/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 417
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-9/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/numeric-separator/valid-9/output.txt
@@ -39,6 +39,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 170
+        format: 'hex'
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/optional-chaining/conditional-decimal/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/optional-chaining/conditional-decimal/output.txt
@@ -51,8 +51,25 @@ Program {
             line: 1
           }
         }
+        test: BooleanLiteral {
+          value: true
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 4
+              index: 4
+              line: 1
+            }
+            start: Object {
+              column: 0
+              index: 0
+              line: 1
+            }
+          }
+        }
         alternate: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -69,6 +86,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 0.3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -79,22 +97,6 @@ Program {
             start: Object {
               column: 5
               index: 5
-              line: 1
-            }
-          }
-        }
-        test: BooleanLiteral {
-          value: true
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 4
-              index: 4
-              line: 1
-            }
-            start: Object {
-              column: 0
-              index: 0
               line: 1
             }
           }
@@ -129,8 +131,25 @@ Program {
             line: 3
           }
         }
+        test: BooleanLiteral {
+          value: true
+          loc: Object {
+            filename: 'input.js'
+            end: Object {
+              column: 4
+              index: 15
+              line: 3
+            }
+            start: Object {
+              column: 0
+              index: 11
+              line: 3
+            }
+          }
+        }
         alternate: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -147,6 +166,7 @@ Program {
         }
         consequent: NumericLiteral {
           value: 0.3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -157,22 +177,6 @@ Program {
             start: Object {
               column: 7
               index: 18
-              line: 3
-            }
-          }
-        }
-        test: BooleanLiteral {
-          value: true
-          loc: Object {
-            filename: 'input.js'
-            end: Object {
-              column: 4
-              index: 15
-              line: 3
-            }
-            start: Object {
-              column: 0
-              index: 11
               line: 3
             }
           }

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/10/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/10/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/11/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/11/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/12/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/14/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/14/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/15/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/15/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/16/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/16/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/18/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/18/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/19/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/19/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/2/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/20/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/20/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/22/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/22/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/23/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/23/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/24/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/24/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/26/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/26/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/27/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/27/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/28/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/28/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/3/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/30/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/30/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/31/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/31/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/32/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/32/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/34/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/34/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/35/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/35/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/36/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/36/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/38/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/38/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/39/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/39/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/4/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/40/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/40/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/42/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/42/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/43/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/43/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/44/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/44/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/46/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/46/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/47/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/47/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/48/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/48/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/50/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/50/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/51/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/51/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/52/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/52/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/54/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/54/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/55/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/55/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/56/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/56/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/58/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/58/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/59/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/59/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/6/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/60/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/60/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/62/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/62/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/63/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/63/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/64/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/64/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/66/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/66/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/67/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/67/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/68/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/68/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/7/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/7/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/8/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/template-literal-invalid-escapes-tagged/8/output.txt
@@ -85,6 +85,7 @@ Program {
           expressions: Array [
             NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -101,6 +102,7 @@ Program {
             }
             NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/comma/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/comma/output.txt
@@ -140,6 +140,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -157,6 +158,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/expression/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/expression/output.txt
@@ -125,6 +125,7 @@ Program {
               }
               argument: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/logical/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/logical/output.txt
@@ -156,6 +156,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/statement/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/throw-expression/statement/output.txt
@@ -109,6 +109,7 @@ Program {
             }
             argument: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_03/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_03/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_04/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_04/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_05/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-no-parens-types/good_05/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -169,6 +170,7 @@ Program {
                   }
                   returnType: NumericLiteralTypeAnnotation {
                     value: 123
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_10/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_10/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -171,6 +172,7 @@ Program {
                   }
                   returnType: NumericLiteralTypeAnnotation {
                     value: 123
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_11/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_11/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_12/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_13/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_13/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -171,6 +172,7 @@ Program {
                   }
                   returnType: NumericLiteralTypeAnnotation {
                     value: 123
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_14/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/anonymous-function-types/good_14/output.txt
@@ -102,6 +102,7 @@ Program {
               }
               body: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -170,6 +171,7 @@ Program {
                   types: Array [
                     NumericLiteralTypeAnnotation {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -186,6 +188,7 @@ Program {
                     }
                     NumericLiteralTypeAnnotation {
                       value: 2
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/class-properties/getter-setter/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/class-properties/getter-setter/output.txt
@@ -483,6 +483,7 @@ Program {
             kind: 'get'
             key: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -552,6 +553,7 @@ Program {
             kind: 'set'
             key: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/iterator/12/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/iterator/12/output.txt
@@ -117,6 +117,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/iterator/13/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/iterator/13/output.txt
@@ -117,6 +117,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-binary/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-binary/output.txt
@@ -89,6 +89,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 123
+                  format: 'binary'
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-float/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-float/output.txt
@@ -89,6 +89,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 123
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-integer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-integer/output.txt
@@ -89,6 +89,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 123
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-octal-2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-octal-2/output.txt
@@ -89,6 +89,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 123
+                  format: 'octal'
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-octal/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/literal-types/number-octal/output.txt
@@ -89,6 +89,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 123
+                  format: 'hex'
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/opaque-type-alias/opaque_in_exp/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/opaque-type-alias/opaque_in_exp/output.txt
@@ -88,6 +88,7 @@ Program {
             }
             init: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -153,6 +154,7 @@ Program {
         }
         right: NumericLiteral {
           value: 4
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/opaque-type-alias/opaque_in_func/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/opaque-type-alias/opaque_in_func/output.txt
@@ -73,6 +73,7 @@ Program {
         arguments: Array [
           NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/predicates/6/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/predicates/6/output.txt
@@ -169,6 +169,7 @@ Program {
                       params: Array [
                         NumericLiteralTypeAnnotation {
                           value: 1
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {
@@ -345,6 +346,7 @@ Program {
                         }
                         NumericLiteralTypeAnnotation {
                           value: 1
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-166/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-166/output.txt
@@ -202,6 +202,7 @@ Program {
                       }
                       argument: NumericLiteral {
                         value: 5
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {
@@ -299,6 +300,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-2083/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-2083/output.txt
@@ -204,6 +204,7 @@ Program {
                   }
                   discriminant: NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -572,6 +573,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 4
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-264/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/regression/issue-264/output.txt
@@ -136,6 +136,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 17
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/trailing-function-commas-type/1/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/trailing-function-commas-type/1/output.txt
@@ -56,6 +56,7 @@ Program {
         }
         body: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/tuples/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/tuples/3/output.txt
@@ -151,6 +151,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 123
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/tuples/4/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/tuples/4/output.txt
@@ -166,6 +166,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 123
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/101/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/101/output.txt
@@ -56,6 +56,7 @@ Program {
         }
         body: NumericLiteral {
           value: 3
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/105/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/105/output.txt
@@ -112,6 +112,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {
@@ -190,6 +191,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/108/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/108/output.txt
@@ -273,6 +273,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -617,6 +618,7 @@ Program {
                   }
                   value: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -1229,6 +1231,7 @@ Program {
                         }
                         value: NumericLiteral {
                           value: 0
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {
@@ -1806,6 +1809,7 @@ Program {
                         }
                         value: NumericLiteral {
                           value: 0
+                          format: undefined
                           loc: Object {
                             filename: 'input.js'
                             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/129/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/129/output.txt
@@ -104,6 +104,7 @@ Program {
                   types: Array [
                     NumericLiteralTypeAnnotation {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -120,6 +121,7 @@ Program {
                     }
                     NumericLiteralTypeAnnotation {
                       value: 2
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {
@@ -153,6 +155,7 @@ Program {
             }
             init: NumericLiteral {
               value: 2
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/130/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/130/output.txt
@@ -157,6 +157,7 @@ Program {
                 types: Array [
                   NumericLiteralTypeAnnotation {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -173,6 +174,7 @@ Program {
                   }
                   NumericLiteralTypeAnnotation {
                     value: 2
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -238,6 +240,7 @@ Program {
                 types: Array [
                   NumericLiteralTypeAnnotation {
                     value: 3
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {
@@ -254,6 +257,7 @@ Program {
                   }
                   NumericLiteralTypeAnnotation {
                     value: 4
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/26/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/26/output.txt
@@ -91,6 +91,7 @@ Program {
               key: StaticPropertyKey {
                 value: NumericLiteral {
                   value: 123
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/44/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/44/output.txt
@@ -182,6 +182,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -198,6 +199,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -214,6 +216,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/50/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/50/output.txt
@@ -215,6 +215,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 42
+                    format: undefined
                     loc: Object {
                       filename: 'input.js'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/55/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/55/output.txt
@@ -151,6 +151,7 @@ Program {
             }
             init: NumericLiteral {
               value: 4
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/builtin/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/builtin/output.txt
@@ -587,6 +587,7 @@ Program {
       }
       right: NumericLiteralTypeAnnotation {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.js'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/negative-number-literal/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-annotations/negative-number-literal/output.txt
@@ -109,6 +109,7 @@ Program {
           }
           NumericLiteralTypeAnnotation {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -125,6 +126,7 @@ Program {
           }
           NumericLiteralTypeAnnotation {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.js'
               end: Object {
@@ -268,6 +270,7 @@ Program {
               }
               argument: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-generics/2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-generics/2/output.txt
@@ -337,6 +337,7 @@ Program {
             }
             init: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-parameter-declaration/arrow_with_jsx/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-parameter-declaration/arrow_with_jsx/output.txt
@@ -56,6 +56,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -160,6 +161,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -281,6 +283,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -499,6 +502,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/type-parameter-declaration/arrow_without_jsx/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/type-parameter-declaration/arrow_without_jsx/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -157,6 +158,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -278,6 +280,7 @@ Program {
         }
         body: NumericLiteral {
           value: 123
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {
@@ -496,6 +499,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 123
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/typeapp-call/rollback-dot/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/typeapp-call/rollback-dot/output.txt
@@ -77,6 +77,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.js'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/typecasts/2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/typecasts/2/output.txt
@@ -225,6 +225,7 @@ Program {
               }
               value: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/typecasts/3/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/typecasts/3/output.txt
@@ -236,6 +236,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.js'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/typecasts/yield-extra-parentheses/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/typecasts/yield-extra-parentheses/output.txt
@@ -236,6 +236,7 @@ Program {
                       }
                       argument: NumericLiteral {
                         value: 3
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/flow/typecasts/yield/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/flow/typecasts/yield/output.txt
@@ -236,6 +236,7 @@ Program {
                       }
                       argument: NumericLiteral {
                         value: 3
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-multi-element-with-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-multi-element-with-initializer/output.txt
@@ -141,6 +141,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {
@@ -238,6 +239,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 1
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-multi-element-with-object/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-multi-element-with-object/output.txt
@@ -419,6 +419,7 @@ Program {
                     }
                     right: NumericLiteral {
                       value: 0
+                      format: undefined
                       loc: Object {
                         filename: 'input.js'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-single-element-with-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/array-pattern-single-element-with-initializer/output.txt
@@ -141,6 +141,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.js'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-multi-element-with-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-multi-element-with-initializer/output.txt
@@ -190,6 +190,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {
@@ -347,6 +348,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-multi-element-with-object/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-multi-element-with-object/output.txt
@@ -495,6 +495,7 @@ Program {
                       }
                       right: NumericLiteral {
                         value: 0
+                        format: undefined
                         loc: Object {
                           filename: 'input.js'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-single-element-with-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/test262/rest-parameter/object-pattern-single-element-with-initializer/output.txt
@@ -190,6 +190,7 @@ Program {
                 }
                 right: NumericLiteral {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.js'
                     end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/async-generic-false-positive/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/async-generic-false-positive/output.txt
@@ -70,6 +70,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {
@@ -117,6 +118,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/default-parameter-values/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/default-parameter-values/output.txt
@@ -53,6 +53,7 @@ Program {
         }
         body: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {
@@ -105,6 +106,7 @@ Program {
               }
               right: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/destructuring/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/destructuring/output.txt
@@ -78,6 +78,7 @@ Program {
         }
         right: NumericLiteral {
           value: 0
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {
@@ -284,6 +285,7 @@ Program {
       }
       expression: NumericLiteral {
         value: 0
+        format: undefined
         loc: Object {
           filename: 'input.ts'
           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/optional-parameter/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/arrow-function/optional-parameter/output.txt
@@ -229,6 +229,7 @@ Program {
             }
             right: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.ts'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/as-const/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/as-const/output.txt
@@ -432,6 +432,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {
@@ -607,6 +608,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -751,6 +753,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -847,6 +850,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {
@@ -1022,6 +1026,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -1546,6 +1551,7 @@ Program {
                 elements: Array [
                   NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -1562,6 +1568,7 @@ Program {
                   }
                   NumericLiteral {
                     value: 2
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -1578,6 +1585,7 @@ Program {
                   }
                   NumericLiteral {
                     value: 3
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -1722,6 +1730,7 @@ Program {
                 elements: Array [
                   NumericLiteral {
                     value: 10
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -1927,6 +1936,7 @@ Program {
                       elements: Array [
                         NumericLiteral {
                           value: 1
+                          format: undefined
                           loc: Object {
                             filename: 'input.ts'
                             end: Object {
@@ -1943,6 +1953,7 @@ Program {
                         }
                         NumericLiteral {
                           value: 2
+                          format: undefined
                           loc: Object {
                             filename: 'input.ts'
                             end: Object {
@@ -1959,6 +1970,7 @@ Program {
                         }
                         NumericLiteral {
                           value: 3
+                          format: undefined
                           loc: Object {
                             filename: 'input.ts'
                             end: Object {
@@ -2060,6 +2072,7 @@ Program {
               elements: Array [
                 NumericLiteral {
                   value: 1
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -2076,6 +2089,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 2
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -2092,6 +2106,7 @@ Program {
                 }
                 NumericLiteral {
                   value: 3
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -2602,6 +2617,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 10
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -2665,6 +2681,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 20
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -2856,6 +2873,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 1
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -2919,6 +2937,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 2
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -2982,6 +3001,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 3
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -3166,6 +3186,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 4
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -3867,6 +3888,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 10
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -4013,6 +4035,7 @@ Program {
                             }
                             right: NumericLiteral {
                               value: 20
+                              format: undefined
                               loc: Object {
                                 filename: 'input.ts'
                                 end: Object {
@@ -4180,6 +4203,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {
@@ -4355,6 +4379,7 @@ Program {
                 }
                 argument: NumericLiteral {
                   value: 10
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {
@@ -4498,6 +4523,7 @@ Program {
                 elements: Array [
                   NumericLiteral {
                     value: 10
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -4687,6 +4713,7 @@ Program {
                             elements: Array [
                               NumericLiteral {
                                 value: 10
+                                format: undefined
                                 loc: Object {
                                   filename: 'input.ts'
                                   end: Object {
@@ -4870,6 +4897,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 10
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -4948,6 +4976,7 @@ Program {
                       elements: Array [
                         NumericLiteral {
                           value: 20
+                          format: undefined
                           loc: Object {
                             filename: 'input.ts'
                             end: Object {
@@ -4964,6 +4993,7 @@ Program {
                         }
                         NumericLiteral {
                           value: 30
+                          format: undefined
                           loc: Object {
                             filename: 'input.ts'
                             end: Object {
@@ -5125,6 +5155,7 @@ Program {
                                 }
                                 value: NumericLiteral {
                                   value: 42
+                                  format: undefined
                                   loc: Object {
                                     filename: 'input.ts'
                                     end: Object {
@@ -5268,6 +5299,7 @@ Program {
               }
               expression: NumericLiteral {
                 value: 10
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {
@@ -5696,6 +5728,7 @@ Program {
                 elements: Array [
                   NumericLiteral {
                     value: 1
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -5712,6 +5745,7 @@ Program {
                   }
                   NumericLiteral {
                     value: 2
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -5728,6 +5762,7 @@ Program {
                   }
                   NumericLiteral {
                     value: 3
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -5905,6 +5940,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 10
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {
@@ -5968,6 +6004,7 @@ Program {
                     }
                     value: NumericLiteral {
                       value: 20
+                      format: undefined
                       loc: Object {
                         filename: 'input.ts'
                         end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/as/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/as/output.txt
@@ -310,6 +310,7 @@ Program {
           }
           expression: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/assert-and-assign/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/assert-and-assign/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/false-positive/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/false-positive/output.txt
@@ -101,6 +101,7 @@ Program {
             }
             right: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.ts'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/multiple-assert-and-assign/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/multiple-assert-and-assign/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 42
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-2/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 2
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-and-assign-2/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-and-assign-2/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-and-assign/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/null-assertion-and-assign/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-after-operator/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-after-operator/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         left: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {
@@ -99,6 +100,7 @@ Program {
           }
           expression: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-and-assign/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-and-assign/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-before-operator/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion-before-operator/output.txt
@@ -54,6 +54,7 @@ Program {
         }
         right: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {
@@ -99,6 +100,7 @@ Program {
           }
           expression: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/cast/type-assertion/output.txt
@@ -68,6 +68,7 @@ Program {
         }
         expression: NumericLiteral {
           value: 1
+          format: undefined
           loc: Object {
             filename: 'input.ts'
             end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/class/members-with-modifier-names/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/class/members-with-modifier-names/output.txt
@@ -327,6 +327,7 @@ Program {
             }
             value: NumericLiteral {
               value: 0
+              format: undefined
               loc: Object {
                 filename: 'input.ts'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/class/modifiers-accessors/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/class/modifiers-accessors/output.txt
@@ -321,6 +321,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -567,6 +568,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -714,6 +716,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -861,6 +864,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -1008,6 +1012,7 @@ Program {
                   }
                   argument: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/class/parameter-properties/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/class/parameter-properties/output.txt
@@ -385,6 +385,7 @@ Program {
                   }
                   right: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {
@@ -467,22 +468,6 @@ Program {
                       line: 10
                     }
                   }
-                  right: NumericLiteral {
-                    value: 0
-                    loc: Object {
-                      filename: 'input.ts'
-                      end: Object {
-                        column: 29
-                        index: 251
-                        line: 10
-                      }
-                      start: Object {
-                        column: 28
-                        index: 250
-                        line: 10
-                      }
-                    }
-                  }
                   meta: PatternMeta {
                     accessibility: 'public'
                     readonly: false
@@ -496,6 +481,23 @@ Program {
                       start: Object {
                         column: 8
                         index: 230
+                        line: 10
+                      }
+                    }
+                  }
+                  right: NumericLiteral {
+                    value: 0
+                    format: undefined
+                    loc: Object {
+                      filename: 'input.ts'
+                      end: Object {
+                        column: 29
+                        index: 251
+                        line: 10
+                      }
+                      start: Object {
+                        column: 28
+                        index: 250
                         line: 10
                       }
                     }

--- a/packages/@romejs/js-parser/test-fixtures/typescript/class/properties/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/class/properties/output.txt
@@ -349,6 +349,7 @@ Program {
             }
             value: NumericLiteral {
               value: 1
+              format: undefined
               loc: Object {
                 filename: 'input.ts'
                 end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/enum/members-strings/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/enum/members-strings/output.txt
@@ -119,6 +119,7 @@ Program {
           }
           initializer: NumericLiteral {
             value: 1
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/enum/members-trailing-comma-with-initializer/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/enum/members-trailing-comma-with-initializer/output.txt
@@ -87,6 +87,7 @@ Program {
           }
           initializer: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/enum/members/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/enum/members/output.txt
@@ -119,6 +119,7 @@ Program {
           }
           initializer: NumericLiteral {
             value: 0
+            format: undefined
             loc: Object {
               filename: 'input.ts'
               end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/export/nested-same-name/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/export/nested-same-name/output.txt
@@ -101,6 +101,7 @@ Program {
               }
               init: NumericLiteral {
                 value: 0
+                format: undefined
                 loc: Object {
                   filename: 'input.ts'
                   end: Object {
@@ -259,6 +260,7 @@ Program {
                       }
                       init: NumericLiteral {
                         value: 1
+                        format: undefined
                         loc: Object {
                           filename: 'input.ts'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/module-namespace/body/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/module-namespace/body/output.txt
@@ -130,6 +130,7 @@ Program {
                   }
                   init: NumericLiteral {
                     value: 0
+                    format: undefined
                     loc: Object {
                       filename: 'input.ts'
                       end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/regression/async-arrow-generic-9560/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/regression/async-arrow-generic-9560/output.txt
@@ -222,6 +222,7 @@ Program {
                       }
                       argument: NumericLiteral {
                         value: 0
+                        format: undefined
                         loc: Object {
                           filename: 'input.ts'
                           end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/literal-number/output.txt
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/literal-number/output.txt
@@ -86,6 +86,7 @@ Program {
                 }
                 typeAnnotation: NumericLiteralTypeAnnotation {
                   value: 0
+                  format: undefined
                   loc: Object {
                     filename: 'input.ts'
                     end: Object {


### PR DESCRIPTION
This PR adds a `format` property to `NumericLiteral` and `NumericLiteralTypeAnnotation`. This contains the preferred printed number format. It can possibly be `octal`, `binary`, `hex` etc. This may not necessarily be honored in the formatter, if say, the value becomes decimal etc.

cc @ooflorent 