### PR TITLE
Async snapshots

### DIFF
--- a/packages/@romejs-runtime/rome/test.ts
+++ b/packages/@romejs-runtime/rome/test.ts
@@ -36,14 +36,16 @@ export interface TestHelper {
   notThrowsAsync(nonThrower: AsyncFunc, message?: string): Promise<void>;
   regex(contents: string, regex: RegExp, message?: string): void;
   notRegex(contents: string, regex: RegExp, message?: string): void;
-  snapshot(expected: unknown, message?: string, fileName?: string): string;
+  snapshot(expected: unknown, message?: string, fileName?: string): Promise<
+    string
+  >;
   snapshotNamed(
     name: string,
     expected: unknown,
     message?: string,
-    fileName?: string,
-  ): string;
-  getSnapshot(snapshotName: string): unknown;
+    filename?: string,
+  ): Promise<string>;
+  getSnapshot(snapshotName: string): Promise<unknown>;
 }
 
 export type TestName = string | Array<string>;

--- a/packages/@romejs/cli-flags/Parser.test.ts
+++ b/packages/@romejs/cli-flags/Parser.test.ts
@@ -31,7 +31,7 @@ async function testParser<T>(t: TestHelper, {
 
   const {diagnostics} = await catchDiagnostics(async () => {
     const flags = await parser.init();
-    t.snapshotNamed('flags', flags);
+    await t.snapshotNamed('flags', flags);
     if (callback !== undefined) {
       callback(parser, flags);
     }
@@ -47,11 +47,11 @@ async function testParser<T>(t: TestHelper, {
     });
   }
 
-  t.snapshotNamed('output', stream.read());
+  await t.snapshotNamed('output', stream.read());
 
   const helpStream = reporter.attachCaptureStream();
   await parser.showHelp();
-  t.snapshotNamed('help', helpStream.read());
+  await t.snapshotNamed('help', helpStream.read());
 }
 
 test('does not allow shorthands', async (t) => {

--- a/packages/@romejs/codec-js-manifest/dependencies.test.ts
+++ b/packages/@romejs/codec-js-manifest/dependencies.test.ts
@@ -9,20 +9,20 @@ import {test} from 'rome';
 import {parseDependencyPattern} from './dependencies';
 import {consumeUnknown} from '@romejs/consume';
 
-test('can parse npm dependency patterns', (t) => {
-  t.snapshot(parseDependencyPattern(
+test('can parse npm dependency patterns', async (t) => {
+  await t.snapshot(parseDependencyPattern(
     consumeUnknown('npm:foo', 'parse/json'),
     false,
   ));
-  t.snapshot(parseDependencyPattern(
-    consumeUnknown('npm:@foo/bar', 'parse/json'),
-    false,
-  ));
-  t.snapshot(parseDependencyPattern(
-    consumeUnknown('npm:foo@1.0.0', 'parse/json'),
-    false,
-  ));
-  t.snapshot(parseDependencyPattern(consumeUnknown(
+  await t.snapshot(parseDependencyPattern(consumeUnknown(
+    'npm:@foo/bar',
+    'parse/json',
+  ), false));
+  await t.snapshot(parseDependencyPattern(consumeUnknown(
+    'npm:foo@1.0.0',
+    'parse/json',
+  ), false));
+  await t.snapshot(parseDependencyPattern(consumeUnknown(
     'npm:@foo/bar@1.0.0',
     'parse/json',
   ), false));

--- a/packages/@romejs/codec-semver/parse.test.ts
+++ b/packages/@romejs/codec-semver/parse.test.ts
@@ -9,7 +9,7 @@ import '@romejs/string-markup';
 import {parseSemverRange, parseSemverVersion} from '@romejs/codec-semver';
 import {test} from 'rome';
 
-test('parse', (t) => {
+test('parse', async (t) => {
   // versions in version mode
   const versionTests = [
     '1.2.3',
@@ -24,13 +24,13 @@ test('parse', (t) => {
     '1.2.3-45pre.42yes+45build',
   ];
   for (const str of versionTests) {
-    t.snapshot(parseSemverVersion({input: str}));
+    await t.snapshot(parseSemverVersion({input: str}));
   }
 
   // loose mode
   const looseRangeTests = ['* - 1.2.3', 'v1.2.3', '||', '', '1.2.3prerelease'];
   for (const str of looseRangeTests) {
-    t.snapshot(parseSemverRange({input: str, loose: true}));
+    await t.snapshot(parseSemverRange({input: str, loose: true}));
 
     t.throws(() => {
       parseSemverRange({input: str, loose: false});
@@ -90,7 +90,7 @@ test('parse', (t) => {
 
   // run range tests
   for (const str of rangeTests) {
-    t.snapshot(parseSemverRange({input: str}));
+    await t.snapshot(parseSemverRange({input: str}));
   }
 
   // ensure ranges throw in version mode

--- a/packages/@romejs/core/test-worker/SnapshotManager.ts
+++ b/packages/@romejs/core/test-worker/SnapshotManager.ts
@@ -5,15 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {AbsoluteFilePath, AbsoluteFilePathSet} from '@romejs/path';
-import {
-  writeFile,
-  readFileText,
-  exists,
-  unlink,
-  readdir,
-  lstat,
-} from '@romejs/fs';
+import {AbsoluteFilePath, AbsoluteFilePathMap} from '@romejs/path';
+import {writeFile, readFileText, exists, unlink} from '@romejs/fs';
 import {TestRunnerOptions} from '../master/testing/types';
 import TestWorkerRunner from './TestWorkerRunner';
 import {descriptions, DiagnosticDescription} from '@romejs/diagnostics';
@@ -31,94 +24,90 @@ function cleanHeading(key: string): string {
   return key.trim();
 }
 
-type SnapshotEntry = Map<string, Map<string, {
+type SnapshotEntry = {
+  testName: string;
+  entryName: string;
   language: undefined | string;
   value: string;
-}>>;
+};
+
+type Snapshot = {
+  exists: boolean;
+  used: boolean;
+  raw: string;
+  entries: Map<string, SnapshotEntry>;
+};
+
+function buildEntriesKey(testName: string, entryName: string): string {
+  return `${testName}#${entryName}`;
+}
 
 export default class SnapshotManager {
   constructor(runner: TestWorkerRunner, testPath: AbsoluteFilePath) {
-    this.path = testPath.getParent().append(
+    this.defaultSnapshotPath = testPath.getParent().append(
       `${testPath.getExtensionlessBasename()}.test.md`,
     );
     this.testPath = testPath;
 
     this.runner = runner;
     this.options = runner.options;
-
-    this.exists = false;
-    this.raw = '';
-
-    this.entries = new Map();
-    this.outputFiles = new Map();
-    this.outputFiles.set(this.path.join(), this.path);
+    this.snapshots = new AbsoluteFilePathMap();
+    this.loadingSnapshotCount = 0;
   }
 
+  loadingSnapshotCount: number;
   testPath: AbsoluteFilePath;
-  path: AbsoluteFilePath;
-  entries: Map<string, SnapshotEntry>;
-  outputFiles: Map<string, AbsoluteFilePath>;
+  defaultSnapshotPath: AbsoluteFilePath;
+
+  snapshots: AbsoluteFilePathMap<Snapshot>;
 
   runner: TestWorkerRunner;
   options: TestRunnerOptions;
 
-  raw: string;
-  exists: boolean;
+  teardown() {
+    if (this.loadingSnapshotCount > 0) {
+      throw new Error();
+    }
+  }
+
+  async init() {
+    await this.loadSnapshot(this.defaultSnapshotPath);
+  }
 
   async emitDiagnostic(metadata: DiagnosticDescription) {
     await this.runner.emitDiagnostic({
       description: metadata,
       location: {
-        filename: this.path.join(),
+        filename: this.defaultSnapshotPath.join(),
       },
     });
   }
 
-  async loadSnapshotFixtures(dir: AbsoluteFilePath) {
-    const filenames: AbsoluteFilePathSet = await readdir(dir);
-    for (const filename of filenames) {
-      const stats = await lstat(filename);
-      if (stats.isFile() && filename.join().endsWith('.test.md')) {
-        this.loadSnapshot(filename);
-      } else if (stats.isDirectory()) {
-        this.loadSnapshotFixtures(filename);
-      }
-    }
-  }
-
-  async load() {
-    const {path: snapshotFile} = this;
-    if (await exists(snapshotFile)) {
-      this.loadSnapshot(snapshotFile);
-    } else {
-      // checks if there are fixtures and load them
-      const fixtureDir = snapshotFile.getParent().append('test-fixtures');
-      if (await exists(fixtureDir)) {
-        this.loadSnapshotFixtures(fixtureDir);
-      }
-    }
-  }
-
-  async loadSnapshot(snapshotFile: AbsoluteFilePath) {
-    if (!(await exists(snapshotFile))) {
+  async loadSnapshot(path: AbsoluteFilePath): Promise<undefined | Snapshot> {
+    if (!(await exists(path))) {
       return;
     }
-
-    this.exists = true;
 
     // If we're force updating, pretend that no snapshots exist on disk
     if (this.options.updateSnapshots) {
       return;
     }
 
-    const file = await readFileText(snapshotFile);
+    const content = await readFileText(path);
     const parser = createSnapshotParser({
-      path: snapshotFile,
-      input: file,
+      path,
+      input: content,
     });
-    this.raw = parser.input;
 
     const nodes = parser.parse();
+
+    const snapshot: Snapshot = {
+      exists: true,
+      used: false,
+      raw: content,
+      entries: new Map(),
+    };
+    this.snapshots.set(path, snapshot);
 
     while (nodes.length > 0) {
       const node = nodes.shift();
@@ -140,7 +129,7 @@ export default class SnapshotManager {
           if (node.type === 'Heading' && node.level === 3) {
             nodes.shift();
 
-            const snapshotName = cleanHeading(node.text);
+            const entryName = cleanHeading(node.text);
 
             const codeBlock = nodes.shift();
             if (codeBlock === undefined || codeBlock.type !== 'CodeBlock') {
@@ -152,25 +141,24 @@ export default class SnapshotManager {
                 );
             }
 
-            this.set({
+            snapshot.entries.set(buildEntriesKey(testName, entryName), {
               testName,
-              snapshotName,
+              entryName,
               language: codeBlock.language,
               value: codeBlock.text,
-              snapshotFile,
             });
+
             continue;
           }
 
           if (node.type === 'CodeBlock') {
             nodes.shift();
 
-            this.set({
+            snapshot.entries.set(buildEntriesKey(testName, '0'), {
               testName,
-              snapshotName: '0',
+              entryName: '0',
               language: node.language,
               value: node.text,
-              snapshotFile,
             });
           }
 
@@ -180,9 +168,11 @@ export default class SnapshotManager {
         continue;
       }
     }
+
+    return snapshot;
   }
 
-  buildSnapShot(snapshotEntries: SnapshotEntry): Array<string> {
+  buildSnapshot(entries: Iterable<SnapshotEntry>): Array<string> {
     // Build the snapshot
     let lines: Array<string> = [];
 
@@ -200,11 +190,21 @@ export default class SnapshotManager {
     );
     pushNewline();
 
+    const testNameToEntries: Map<string, Map<string, SnapshotEntry>> = new Map();
+    for (const entry of entries) {
+      let entriesByTestName = testNameToEntries.get(entry.testName);
+      if (entriesByTestName === undefined) {
+        entriesByTestName = new Map();
+        testNameToEntries.set(entry.testName, entriesByTestName);
+      }
+      entriesByTestName.set(entry.entryName, entry);
+    }
+
     // Get test names and sort them so they are in a predictable
-    const testNames = Array.from(snapshotEntries.keys()).sort();
+    const testNames = Array.from(testNameToEntries.keys()).sort();
 
     for (const testName of testNames) {
-      const entries = snapshotEntries.get(testName);
+      const entries = testNameToEntries.get(testName);
       if (entries === undefined) {
         throw new Error('Impossible');
       }
@@ -212,9 +212,9 @@ export default class SnapshotManager {
       lines.push(`## \`${testName}\``);
       pushNewline();
 
-      const snapshotNames = Array.from(entries.keys()).sort();
+      const entryNames = Array.from(entries.keys()).sort();
 
-      for (const snapshotName of snapshotNames) {
+      for (const snapshotName of entryNames) {
         const entry = entries.get(snapshotName);
         if (entry === undefined) {
           throw new Error('Impossible');
@@ -224,7 +224,7 @@ export default class SnapshotManager {
         const language = entry.language === undefined ? '' : entry.language;
 
         // If the test only has one snapshot then omit the heading
-        const skipHeading = snapshotName === '0' && snapshotNames.length === 1;
+        const skipHeading = snapshotName === '0' && entryNames.length === 1;
         if (!skipHeading) {
           lines.push(`### \`${snapshotName}\``);
         }
@@ -246,100 +246,87 @@ export default class SnapshotManager {
       return;
     }
 
-    // No point producing an empty snapshot file
-    if (this.entries.size === 0) {
-      if (this.exists) {
-        if (this.options.freezeSnapshots) {
-          await this.emitDiagnostic(descriptions.SNAPSHOTS.REDUNDANT);
-        } else {
-          // Remove the snapshot file as there were none ran
-          await unlink(this.path);
-        }
-      }
-      return;
-    }
-
-    for (const snapshotFilename of this.entries.keys()) {
-      const entries = this.entries.get(snapshotFilename);
-      if (entries === undefined) {
-        continue;
-      }
-      const lines = this.buildSnapShot(entries);
+    for (const [path, {used, exists, raw, entries}] of this.snapshots) {
+      const lines = this.buildSnapshot(entries.values());
       const formatted = lines.join('\n');
 
       if (this.options.freezeSnapshots) {
-        if (!this.exists) {
+        if (!used) {
+          await this.emitDiagnostic(descriptions.SNAPSHOTS.REDUNDANT);
+        } else if (exists) {
           await this.emitDiagnostic(descriptions.SNAPSHOTS.MISSING);
-        } else if (formatted !== this.raw) {
+        } else if (formatted !== raw) {
           await this.emitDiagnostic(descriptions.SNAPSHOTS.INCORRECT(
-            this.raw,
+            raw,
             formatted,
           ));
         }
-      } else if (formatted !== this.raw) {
-        // Save the file
-        const snapshotFile = this.outputFiles.get(snapshotFilename);
-        if (snapshotFile !== undefined) {
-          await writeFile(snapshotFile, formatted);
+      } else {
+        if (exists && !used) {
+          // If a snapshot wasn't used or is empty then delete it!
+          await unlink(path);
+        } else if (used && formatted !== raw) {
+          // Fresh snapshot!
+          await writeFile(path, formatted);
         }
       }
     }
   }
 
-  get(
+  async get(
     testName: string,
-    snapshotName: string,
-    snapshotFile?: AbsoluteFilePath,
-  ): undefined | string {
-    if (snapshotFile === undefined) {
-      snapshotFile = this.path;
+    entryName: string,
+    snapshotPath: AbsoluteFilePath = this.defaultSnapshotPath,
+  ): Promise<undefined | string> {
+    let snapshot = this.snapshots.get(snapshotPath);
+
+    if (snapshot === undefined) {
+      snapshot = await this.loadSnapshot(snapshotPath);
     }
-    const snapshotsForFile = this.entries.get(snapshotFile.join());
-    if (snapshotsForFile !== undefined) {
-      const entries = snapshotsForFile.get(testName);
-      if (entries !== undefined) {
-        const entry = entries.get(snapshotName);
-        if (entry !== undefined) {
-          return entry.value;
-        }
-      }
+
+    if (snapshot === undefined) {
+      return undefined;
     }
-    return undefined;
+
+    snapshot.used = true;
+
+    const entry = snapshot.entries.get(buildEntriesKey(testName, entryName));
+    if (entry === undefined) {
+      return undefined;
+    } else {
+      return entry.value;
+    }
   }
 
   set({
+    testName,
+    entryName,
     value,
     language,
-    testName,
-    snapshotName,
-    snapshotFile,
+    snapshotPath = this.defaultSnapshotPath,
   }: {
+    testName: string;
+    entryName: string;
     value: string;
     language: undefined | string;
-    testName: string;
-    snapshotName: string;
-    snapshotFile?: AbsoluteFilePath;
+    snapshotPath: undefined | AbsoluteFilePath;
   }) {
-    if (snapshotFile === undefined) {
-      snapshotFile = this.path;
-    }
-    const snapshotFileName = snapshotFile.join();
-    let snapshotsForFile = this.entries.get(snapshotFileName);
-    if (snapshotsForFile === undefined) {
-      snapshotsForFile = new Map();
-      this.entries.set(snapshotFileName, snapshotsForFile);
-    }
-
-    let entries = snapshotsForFile.get(testName);
-    if (entries === undefined) {
-      entries = new Map();
-      snapshotsForFile.set(testName, entries);
+    let snapshot = this.snapshots.get(snapshotPath);
+    if (snapshot === undefined) {
+      snapshot = {
+        raw: '',
+        exists: false,
+        used: true,
+        entries: new Map(),
+      };
+      this.snapshots.set(snapshotPath, snapshot);
     }
 
-    entries.set(snapshotName, {value, language});
-
-    if (!this.outputFiles.has(snapshotFileName)) {
-      this.outputFiles.set(snapshotFileName, snapshotFile);
-    }
+    snapshot.entries.set(buildEntriesKey(testName, entryName), {
+      testName,
+      entryName,
+      language,
+      value,
+    });
   }
 }

--- a/packages/@romejs/core/test-worker/TestWorkerRunner.ts
+++ b/packages/@romejs/core/test-worker/TestWorkerRunner.ts
@@ -411,7 +411,7 @@ export default class TestWorkerRunner {
   async prepare(): Promise<void> {
     return this.wrap(async () => {
       // Setup
-      await this.snapshotManager.load();
+      await this.snapshotManager.init();
       await this.discoverTests();
       await this.emitFoundTests();
 

--- a/packages/@romejs/js-ast-utils/getCompletionRecords.test.ts
+++ b/packages/@romejs/js-ast-utils/getCompletionRecords.test.ts
@@ -17,25 +17,30 @@ function helper(input: string) {
   }).body[0]).body);
 }
 
-test('invalid', (t) => {
-  t.snapshot(helper(`{}`));
-  t.snapshot(helper(`'foobar';`));
-  t.snapshot(helper(`if (bar) {'foobar';}`));
-  t.snapshot(helper(`if (bar) {'foobar';} else {}`));
-  t.snapshot(helper(`switch (foo) {}`));
-  t.snapshot(helper(`switch (foo) {case 'bar': {}}`));
-  t.snapshot(helper(`switch (foo) {default: {}}`));
+test('invalid', async (t) => {
+  await t.snapshot(helper(`{}`));
+  await t.snapshot(helper(`'foobar';`));
+  await t.snapshot(helper(`if (bar) {'foobar';}`));
+  await t.snapshot(helper(`if (bar) {'foobar';} else {}`));
+  await t.snapshot(helper(`switch (foo) {}`));
+  await t.snapshot(helper(`switch (foo) {case 'bar': {}}`));
+  await t.snapshot(helper(`switch (foo) {default: {}}`));
 });
 
-test('completions', (t) => {
-  t.snapshot(helper(`return false;`));
-  t.snapshot(helper(`return; invalid;`));
-  t.snapshot(helper(`if (bar) {return false;}`));
-  t.snapshot(helper(`if (bar) {return false;} else {return true;}`));
-  t.snapshot(helper(`switch (foo) {default: {return false;}}`));
-  t.snapshot(helper(`switch (foo) {default: {return false;}}`));
+test('completions', async (t) => {
+  await t.snapshot(helper(`return false;`));
+  await t.snapshot(helper(`return; invalid;`));
+  await t.snapshot(helper(`if (bar) {return false;}`));
+  await t.snapshot(helper(`if (bar) {return false;} else {return true;}`));
+  await t.snapshot(helper(`switch (foo) {default: {return false;}}`));
+  await t.snapshot(helper(`switch (foo) {default: {return false;}}`));
 });
 
-test('mix', (t) => {
-  t.snapshot(helper(`switch (foo) {default: {if (true) {return false;}}}`));
-});
+test(
+  'mix',
+  async (t) => {
+    await t.snapshot(helper(
+      `switch (foo) {default: {if (true) {return false;}}}`,
+    ));
+  },
+);

--- a/packages/@romejs/js-compiler/api/analyzeDependencies.test.ts
+++ b/packages/@romejs/js-compiler/api/analyzeDependencies.test.ts
@@ -25,7 +25,7 @@ async function testAnalyzeDeps(input: string, sourceType: ConstSourceType) {
 }
 
 test("discovers require('module') call", async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import * as foo from 'foo';
 
       function yeah() {
@@ -35,13 +35,13 @@ test("discovers require('module') call", async (t) => {
 });
 
 test('ignores require(dynamic) call', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       require(dynamic);
     `, 'module'));
 });
 
 test('ignores require() call if shadowed', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       {
         function require() {}
         require('yes');
@@ -55,7 +55,7 @@ test('ignores require() call if shadowed', async (t) => {
 });
 
 test("discovers async import('foo')", async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import('./foo');
 
       function yes() {
@@ -65,13 +65,13 @@ test("discovers async import('foo')", async (t) => {
 });
 
 test('discovers local export specifiers', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export {foo, bar, yes as no};
     `, 'module'));
 });
 
 test('discovers export declarations', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export const yes = '';
       export function foo() {}
       export class Bar {}
@@ -79,73 +79,73 @@ test('discovers export declarations', async (t) => {
 });
 
 test('discovers export default', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export default 'yes';
     `, 'module'));
 });
 
 test('discovers export from', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export {foo, bar, default as no, boo as noo} from 'foobar';
     `, 'module'));
 });
 
 test('discovers export star', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export * from 'foobar';
     `, 'module'));
 });
 
 test('discovers import star', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import * as bar from 'foobar';
     `, 'module'));
 });
 
 test('discovers import specifiers', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import {bar, foo, default as lol, ya as to} from 'foobar';
     `, 'module'));
 });
 
 test('discovers import default', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import bar from 'foobar';
     `, 'module'));
 });
 
 test('discovers commonjs exports', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       exports.yes = function() {};
     `, 'script'));
 });
 
 test('discovers commonjs module.exports', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       module.exports = function() {};
     `, 'script'));
 });
 
 test('discovers top level await', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       await foobar();
     `, 'module'));
 });
 
 test('correctly identifies a file with es imports as es', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       import 'bar';
     `, 'module'));
 });
 
 test('correctly identifies a file with es exports as es', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export const foo = 'bar';
     `, 'module'));
 });
 
 test('correctly identifies a file with cjs exports as cjs', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       exports.foo = 'bar';
     `, 'module'));
 });
@@ -155,21 +155,21 @@ test(
   async (
     t,
   ) => {
-    t.snapshot(await testAnalyzeDeps(`
+    await t.snapshot(await testAnalyzeDeps(`
       foo();
     `, 'module'));
   },
 );
 
 test('disallow mix of es and cjs exports', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
       export const foo = 'bar';
       exports.bar = 'foo';
     `, 'script'));
 });
 
 test('defines topLevelLocalBindings', async (t) => {
-  t.snapshot(await testAnalyzeDeps(`
+  await t.snapshot(await testAnalyzeDeps(`
     import {bar} from 'foo';
     const foo = 'bar';
   `, 'module'));

--- a/packages/@romejs/js-compiler/api/lint.test.ts
+++ b/packages/@romejs/js-compiler/api/lint.test.ts
@@ -103,7 +103,7 @@ export async function testLint(t: TestHelper, input: string, {
   }));
 
   if (format) {
-    t.snapshotNamed(`${snapshotName}: formatted`, res.src);
+    await t.snapshotNamed(`${snapshotName}: formatted`, res.src);
   }
 
   t.clearAdvice();

--- a/packages/@romejs/js-compiler/suppressions.test.ts
+++ b/packages/@romejs/js-compiler/suppressions.test.ts
@@ -29,8 +29,8 @@ function generateComment(value: string, line: number): CommentBlock {
   };
 }
 
-test('single category', (t) => {
-  t.snapshot(extractSuppressionsFromComments([
+test('single category', async (t) => {
+  await t.snapshot(extractSuppressionsFromComments([
     generateComment('rome-suppress foo', 1),
     generateComment('* rome-suppress foo', 2),
     generateComment(' * rome-suppress foo', 3),
@@ -38,8 +38,8 @@ test('single category', (t) => {
   ]));
 });
 
-test('multiple categories', (t) => {
-  t.snapshot(extractSuppressionsFromComments([
+test('multiple categories', async (t) => {
+  await t.snapshot(extractSuppressionsFromComments([
     generateComment('rome-suppress foo bar', 1),
     generateComment('* rome-suppress foo bar', 2),
     generateComment(' * rome-suppress foo bar', 3),
@@ -50,14 +50,14 @@ test('multiple categories', (t) => {
   ]));
 });
 
-test('typos', (t) => {
-  t.snapshot(extractSuppressionsFromComments([
+test('typos', async (t) => {
+  await t.snapshot(extractSuppressionsFromComments([
     generateComment('rome-ignore foo bar', 1),
   ]));
 });
 
-test('duplicates', (t) => {
-  t.snapshot(extractSuppressionsFromComments([
+test('duplicates', async (t) => {
+  await t.snapshot(extractSuppressionsFromComments([
     generateComment('rome-suppress foo foo', 1),
   ]));
 });

--- a/packages/@romejs/js-parser/index.test.ts
+++ b/packages/@romejs/js-parser/index.test.ts
@@ -9,10 +9,9 @@ import {parseJS} from '@romejs/js-parser';
 import {createFixtureTests} from '@romejs/test-helpers';
 import {ConstProgramSyntax} from '@romejs/js-ast';
 import {removeCarriageReturn} from '@romejs/string-utils';
-import {createAbsoluteFilePath} from '@romejs/path';
 
 const promise = createFixtureTests(
-  (fixture, t) => {
+  async (fixture, t) => {
     const {options, files} = fixture;
 
     // Get the input JS
@@ -72,7 +71,7 @@ const promise = createFixtureTests(
     const outputFile = inputFile.absolute.getParent().append(
       `${inputFile.absolute.getExtensionlessBasename()}.test.md`,
     ).join();
-    t.snapshot(ast, undefined, outputFile);
+    await t.snapshot(ast, undefined, outputFile);
   },
 );
 

--- a/packages/@romejs/path-match/parse.test.ts
+++ b/packages/@romejs/path-match/parse.test.ts
@@ -13,39 +13,39 @@ function _parsePathPattern(input: string): PathPattern {
   return parsePathPattern({input});
 }
 
-test('pattern', (t) => {
+test('pattern', async (t) => {
   // Negate and wildcard
-  t.snapshot(_parsePathPattern('!foo'));
-  t.snapshot(_parsePathPattern(''));
+  await t.snapshot(_parsePathPattern('!foo'));
+  await t.snapshot(_parsePathPattern(''));
 
   // Trailing slash and wildcards
-  t.snapshot(_parsePathPattern('/foo/bar'));
-  t.snapshot(_parsePathPattern('*/foo/bar'));
-  t.snapshot(_parsePathPattern('**/foo/bar'));
-  t.snapshot(_parsePathPattern('**/*foo/bar'));
+  await t.snapshot(_parsePathPattern('/foo/bar'));
+  await t.snapshot(_parsePathPattern('*/foo/bar'));
+  await t.snapshot(_parsePathPattern('**/foo/bar'));
+  await t.snapshot(_parsePathPattern('**/*foo/bar'));
 
   // Random
-  t.snapshot(_parsePathPattern('foo'));
-  t.snapshot(_parsePathPattern('foo/'));
-  t.snapshot(_parsePathPattern('foo/bar'));
-  t.snapshot(_parsePathPattern('foo//bar'));
-  t.snapshot(_parsePathPattern('foo/*/bar'));
-  t.snapshot(_parsePathPattern('foo/**/bar'));
-  t.snapshot(_parsePathPattern('foo/*bar'));
-  t.snapshot(_parsePathPattern('foo/bar*'));
-  t.snapshot(_parsePathPattern('foo/*bar*'));
-  t.snapshot(_parsePathPattern('foo/*bar*foob'));
+  await t.snapshot(_parsePathPattern('foo'));
+  await t.snapshot(_parsePathPattern('foo/'));
+  await t.snapshot(_parsePathPattern('foo/bar'));
+  await t.snapshot(_parsePathPattern('foo//bar'));
+  await t.snapshot(_parsePathPattern('foo/*/bar'));
+  await t.snapshot(_parsePathPattern('foo/**/bar'));
+  await t.snapshot(_parsePathPattern('foo/*bar'));
+  await t.snapshot(_parsePathPattern('foo/bar*'));
+  await t.snapshot(_parsePathPattern('foo/*bar*'));
+  await t.snapshot(_parsePathPattern('foo/*bar*foob'));
 
   // Comments
-  t.snapshot(_parsePathPattern('# foobar'));
-  t.snapshot(_parsePathPattern('foo/bar # foobar'));
-  t.snapshot(_parsePathPattern('foo/bar\\#foobar'));
-  t.snapshot(_parsePathPattern('foo/\\#foobar'));
+  await t.snapshot(_parsePathPattern('# foobar'));
+  await t.snapshot(_parsePathPattern('foo/bar # foobar'));
+  await t.snapshot(_parsePathPattern('foo/bar\\#foobar'));
+  await t.snapshot(_parsePathPattern('foo/\\#foobar'));
 
   // Windows separators
-  t.snapshot(_parsePathPattern('\\\\foo\\\\bar'));
-  t.snapshot(_parsePathPattern('*\\\\foo\\\\bar'));
-  t.snapshot(_parsePathPattern('**\\\\foo\\\\bar'));
-  t.snapshot(_parsePathPattern('**\\\\*foo\\\\bar'));
-  t.snapshot(_parsePathPattern('hello\\\\world'));
+  await t.snapshot(_parsePathPattern('\\\\foo\\\\bar'));
+  await t.snapshot(_parsePathPattern('*\\\\foo\\\\bar'));
+  await t.snapshot(_parsePathPattern('**\\\\foo\\\\bar'));
+  await t.snapshot(_parsePathPattern('**\\\\*foo\\\\bar'));
+  await t.snapshot(_parsePathPattern('hello\\\\world'));
 });

--- a/packages/@romejs/string-markup/parse.test.ts
+++ b/packages/@romejs/string-markup/parse.test.ts
@@ -10,15 +10,17 @@ import {parseMarkup} from './parse';
 
 test(
   'should not parse string escapes',
-  (t) => {
-    t.snapshot(parseMarkup('<filelink target="C:\\Users\\sebmck\\file.ts" />'));
-    t.snapshot(
+  async (t) => {
+    await t.snapshot(parseMarkup(
+      '<filelink target="C:\\Users\\sebmck\\file.ts" />',
+    ));
+    await t.snapshot(
       parseMarkup(
         '<info>[MemoryFileSystem] Adding new project folder C:\\Users\\sebmck\\rome</info>',
       ),
     );
 
-    t.snapshot(
+    await t.snapshot(
       parseMarkup(
         '  \\<info>[MemoryFileSystem] Adding new project folder C:\\\\Users\\\\Sebastian\\\\rome\\\\\\</info>\n        <error><emphasis>^</emphasis></error> ',
       ),


### PR DESCRIPTION
This PR changes the `t.snapshot` methods to be async. In the process I cleaned up the current snapshot manager code to support n snapshots.