### PR TITLE
Fix npm can't install dist folder as missing package version

### DIFF
--- a/packages/rome/package.json
+++ b/packages/rome/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rome",
+  "version": "0.0.2",
   "type": "module",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
This PR fix #313. Just add version number to `/packages/rome/package.json` so **npm** could install dist folder.