### PR TITLE
Add ignoreFlags option to cli-flags

### DIFF
--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -162,6 +162,7 @@ export default async function cli() {
         category: local.category,
         description: local.description,
         defineFlags: local.defineFlags,
+        ignoreFlags: local.ignoreFlags,
         examples: local.examples,
         usage: local.usage,
         callback(_commandFlags) {
@@ -180,6 +181,7 @@ export default async function cli() {
         category: master.category,
         description: master.description,
         defineFlags: master.defineFlags,
+        ignoreFlags: master.ignoreFlags,
         usage: master.usage,
         examples: master.examples,
 

--- a/packages/@romejs/core/client/commands/lsp.ts
+++ b/packages/@romejs/core/client/commands/lsp.ts
@@ -8,7 +8,6 @@
 import {commandCategories} from '../../common/commands';
 import {createLocalCommand} from '../commands';
 import ClientRequest from '../ClientRequest';
-import {Consumer} from '@romejs/consume';
 
 export default createLocalCommand({
   description: 'connect to an lsp',
@@ -16,10 +15,10 @@ export default createLocalCommand({
   usage: '',
   examples: [],
 
-  defineFlags(consumer: Consumer) {
-    // vscode-languageclient adds these on
-    consumer.get('stdio').asBooleanOrVoid();
-    consumer.get('clientProcessId').asStringOrVoid();
+  // vscode-languageclient adds these on
+  ignoreFlags: ['stdio', 'clientProcessId'],
+
+  defineFlags() {
     return {};
   },
 

--- a/packages/@romejs/core/common/commands.ts
+++ b/packages/@romejs/core/common/commands.ts
@@ -17,6 +17,7 @@ export type SharedCommand<Flags extends Dict<unknown>> = {
     description: string;
     command: string;
   }>;
+  ignoreFlags?: Array<string>;
   allowRequestFlags?: Array<'review' | 'watch' | 'allowDirty'>;
 };
 


### PR DESCRIPTION
This PR adds an `ignoreFlags` array you can specify on a command, or on the root flag parser options.

This marks the flag as used, and ignores it when checking for incorrect casing and shorthand usage. This is used in the `rome lsp` command as there's some default flags passed by `vscode-languageclient`.

cc @KevinKelbie 