### PR TITLE
Use parser.input rather than the raw file content in SnapshotManager

### DIFF
--- a/packages/@romejs/core/test-worker/SnapshotManager.ts
+++ b/packages/@romejs/core/test-worker/SnapshotManager.ts
@@ -104,7 +104,7 @@ export default class SnapshotManager {
     const snapshot: Snapshot = {
       exists: true,
       used: false,
-      raw: content,
+      raw: parser.input,
       entries: new Map(),
     };
     this.snapshots.set(path, snapshot);


### PR DESCRIPTION
`parser.input` will have removed the carriage returns