### PR TITLE
Fix TSMappedType formatting

### DIFF
--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -67,9 +67,13 @@ type OutputMessagesValue<Value> = Value extends string
           ? OutputMessagesFactory<Value>
           : never;
 
-type OutputMessagesCategory<Input extends InputMessagesCategory> = { [Key in keyof Input]: OutputMessagesValue<Input[Key]> };
+type OutputMessagesCategory<Input extends InputMessagesCategory> = {
+  [Key in keyof Input]: OutputMessagesValue<Input[Key]>
+};
 
-type OutputMessages<Input extends InputMessages> = { [Key in keyof Input]: OutputMessagesCategory<Input[Key]> };
+type OutputMessages<Input extends InputMessages> = {
+  [Key in keyof Input]: OutputMessagesCategory<Input[Key]>
+};
 
 // This is a lot of gross meta programming
 function createMessages<Input extends InputMessages>(

--- a/packages/@romejs/js-ast/utils.ts
+++ b/packages/@romejs/js-ast/utils.ts
@@ -22,16 +22,15 @@ type JustNodeKeysProp<K, V> = V extends
   ? K
   : never;
 
-type JustNodeKeys<T> = ExcludeCoreNodeKeys<{ [K in keyof T]: JustNodeKeysProp<
-  K,
-  NonNullable<T[K]>
-> }[keyof T]>;
+type JustNodeKeys<T> = ExcludeCoreNodeKeys<
+  {[K in keyof T]: JustNodeKeysProp<K, NonNullable<T[K]>>}[keyof T]
+>;
 
 type ExcludeCoreNodeKeys<T> = Exclude<T, keyof JSNodeBase>;
 
-type VisitorKeys<T> = { [K in JustNodeKeys<T>]: true };
+type VisitorKeys<T> = {[K in JustNodeKeys<T>]: true};
 
-type BindingKeys<T> = { [K in JustNodeKeys<T>]?: true };
+type BindingKeys<T> = {[K in JustNodeKeys<T>]?: true};
 
 type CreateBuilderOptions<Node> = {
   bindingKeys: BindingKeys<Node>;

--- a/packages/@romejs/js-compiler/types.ts
+++ b/packages/@romejs/js-compiler/types.ts
@@ -28,7 +28,9 @@ export type TransformStageFactory = (
   options: Object,
 ) => Transforms;
 
-export type TransformStageFactories = { [key in TransformStageName]: TransformStageFactory };
+export type TransformStageFactories = {
+  [key in TransformStageName]: TransformStageFactory
+};
 
 //
 export type Transform =

--- a/packages/@romejs/js-formatter/builders/types/IntersectionTypeAnnotation.ts
+++ b/packages/@romejs/js-formatter/builders/types/IntersectionTypeAnnotation.ts
@@ -61,6 +61,8 @@ export default function IntersectionTypeAnnotation(
 
 function isObjectType(node: AnyNode): boolean {
   return (
-    node.type === 'FlowObjectTypeAnnotation' || node.type === 'TSTypeLiteral'
+    node.type === 'FlowObjectTypeAnnotation' ||
+    node.type === 'TSMappedType' ||
+    node.type === 'TSTypeLiteral'
   );
 }

--- a/packages/@romejs/js-formatter/builders/typescript/TSMappedType.ts
+++ b/packages/@romejs/js-formatter/builders/typescript/TSMappedType.ts
@@ -7,13 +7,13 @@
 
 import {TSMappedType} from '@romejs/js-ast';
 import {Builder} from '@romejs/js-formatter';
-import {Token, concat, space} from '../../tokens';
+import {Token, concat, group, indent, softline, space} from '../../tokens';
 
 export default function TSMappedType(
   builder: Builder,
   node: TSMappedType,
 ): Token {
-  const tokens: Array<Token> = ['{', space];
+  const tokens: Array<Token> = [];
 
   if (node.readonly) {
     tokens.push(tokenIfPlusMinus(builder, node.readonly), 'readonly', space);
@@ -38,15 +38,18 @@ export default function TSMappedType(
     tokens.push(':', space, builder.tokenize(node.typeAnnotation, node));
   }
 
-  tokens.push(space, '}');
-
-  return concat(tokens);
+  return group(
+    concat(['{', indent(concat([softline, concat(tokens)])), softline, '}']),
+  );
 }
 
 function tokenIfPlusMinus(builder: Builder, token: string | true): Token {
-  if (token !== true) {
-    return token;
-  } else {
-    return '';
+  switch (token) {
+    case '+':
+    case '-':
+      return token;
+
+    default:
+      return '';
   }
 }

--- a/packages/@romejs/js-formatter/builders/typescript/TSTypeParameterDeclaration.ts
+++ b/packages/@romejs/js-formatter/builders/typescript/TSTypeParameterDeclaration.ts
@@ -21,7 +21,9 @@ export default function TSTypeParameterDeclaration(
   const shouldInline =
     params.length === 1 &&
     params[0].type !== 'IntersectionTypeAnnotation' &&
-    params[0].type !== 'UnionTypeAnnotation';
+    params[0].type !== 'UnionTypeAnnotation' &&
+    params[0].type !== 'TSIndexedAccessType' &&
+    params[0].type !== 'TSMappedType';
 
   if (shouldInline) {
     return concat(['<', builder.tokenize(params[0], node), '>']);

--- a/packages/@romejs/js-parser/tokenizer/state.ts
+++ b/packages/@romejs/js-parser/tokenizer/state.ts
@@ -20,7 +20,7 @@ import {
   ob1Number1,
 } from '@romejs/ob1';
 
-type Scopes = { [K in ScopeType]?: Array<unknown> };
+type Scopes = {[K in ScopeType]?: Array<unknown>};
 
 export type State = {
   diagnostics: Diagnostics;

--- a/packages/@romejs/messages/index.ts
+++ b/packages/@romejs/messages/index.ts
@@ -20,7 +20,9 @@ type MessagesShape = {
 
 type Factory = (...args: Array<unknown>) => string;
 
-type FactoryObject<Messages extends MessagesShape> = { [P in keyof Messages]: Factory };
+type FactoryObject<Messages extends MessagesShape> = {
+  [P in keyof Messages]: Factory
+};
 
 export function createMessageFactory<Messages extends MessagesShape>(
   messages: Messages,

--- a/packages/@romejs/project/load.ts
+++ b/packages/@romejs/project/load.ts
@@ -485,7 +485,7 @@ function extendProjectConfig(
 type MergedPartialConfig<
   A extends PartialProjectConfig,
   B extends PartialProjectConfig
-> = { [Key in keyof ProjectConfigObjects]: A[Key] & B[Key] };
+> = {[Key in keyof ProjectConfigObjects]: A[Key] & B[Key]};
 
 function mergePartialConfig<
   A extends PartialProjectConfig,

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -86,8 +86,9 @@ export type ProjectConfigTarget = {
 
 // This is a project config that contains only things that can be JSON serializable
 // This is used to transport and reserialize projects in workers
-export type ProjectConfigJSON = ProjectConfigJSONObjectReducer<ProjectConfigBase> &
-  { [ObjectKey in keyof ProjectConfigObjects]: ProjectConfigJSONPropertyReducer<ProjectConfigObjects[ObjectKey]> };
+export type ProjectConfigJSON = ProjectConfigJSONObjectReducer<ProjectConfigBase> & {
+  [ObjectKey in keyof ProjectConfigObjects]: ProjectConfigJSONPropertyReducer<ProjectConfigObjects[ObjectKey]>
+};
 
 // Weird way to get the value type from a map
 // rome-suppress-next-line lint/noExplicitAny
@@ -108,7 +109,9 @@ type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
                   ? ProjectConfigJSONObjectReducer<Type>
                   : Type;
 
-type ProjectConfigJSONObjectReducer<Object> = { [PropertyKey in keyof Object]: ProjectConfigJSONPropertyReducer<Object[PropertyKey]> };
+type ProjectConfigJSONObjectReducer<Object> = {
+  [PropertyKey in keyof Object]: ProjectConfigJSONPropertyReducer<Object[PropertyKey]>
+};
 
 // Base of a project config without any objects
 type ProjectConfigBase = {
@@ -118,8 +121,9 @@ type ProjectConfigBase = {
 };
 
 // Data structure we pass around when normalizing and merging project configs
-export type PartialProjectConfig = Partial<ProjectConfigBase> &
-  { [Key in keyof ProjectConfigObjects]: PartialProjectValue<ProjectConfigObjects[Key]> };
+export type PartialProjectConfig = Partial<ProjectConfigBase> & {
+  [Key in keyof ProjectConfigObjects]: PartialProjectValue<ProjectConfigObjects[Key]>
+};
 
 // rome-suppress-next-line lint/noExplicitAny
 type PartialProjectValue<Type> = Type extends Map<string, any>

--- a/packages/@romejs/typescript-helpers/index.ts
+++ b/packages/@romejs/typescript-helpers/index.ts
@@ -16,17 +16,19 @@ export type Dict<T> = {
   [key: string]: T;
 };
 
-export type RequiredProps<Obj, Keys extends keyof Obj> = Omit<Obj, Keys> &
-  { [Key in Keys]-?: NonNullable<Obj[Key]> };
+export type RequiredProps<Obj, Keys extends keyof Obj> = Omit<Obj, Keys> & {
+  [Key in Keys]-?: NonNullable<Obj[Key]>
+};
 
-export type OptionalProps<Obj, Keys extends keyof Obj> = Omit<Obj, Keys> &
-  { [Key in Keys]?: Obj[Key] };
+export type OptionalProps<Obj, Keys extends keyof Obj> = Omit<Obj, Keys> & {
+  [Key in Keys]?: Obj[Key]
+};
 
 // Turn a type that contains interfaces into regular objects
 export type InterfaceToObject<T> = T extends {
 
 }
-  ? { [K in keyof T]: InterfaceToObject<T[K]> }
+  ? {[K in keyof T]: InterfaceToObject<T[K]>}
   : T;
 
 export type UnknownObject = Dict<unknown>;


### PR DESCRIPTION
Before the change, a `TSMappedType` node was not wrapping when its line width with exceeded the print width.

Before:
```ts
type ProjectConfigJSONObjectReducer<Object> = { [PropertyKey in keyof Object]: ProjectConfigJSONPropertyReducer<Object[PropertyKey]> };

type JustNodeKeys<T> = ExcludeCoreNodeKeys<{[K in keyof T]: JustNodeKeysProp<K, NonNullable<T[K]>>}[keyof T]>;
```

After:
```ts
type ProjectConfigJSONObjectReducer<Object> = {
  [PropertyKey in keyof Object]: ProjectConfigJSONPropertyReducer<
    Object[PropertyKey]
  >
};

type JustNodeKeys<T> = ExcludeCoreNodeKeys<
  {[K in keyof T]: JustNodeKeysProp<K, NonNullable<T[K]>>}[keyof T]
>;
```