### PR TITLE
Fix nested conditional expression formatting

### DIFF
--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -62,10 +62,10 @@ type OutputMessagesValue<Value> = Value extends string
       message: DiagnosticBlessedMessage;
     }
   : Value extends DiagnosticMetadataString
-      ? OuputMessagesFactoryReturn<Value>
-      : Value extends InputMessagesFactory
-          ? OutputMessagesFactory<Value>
-          : never;
+    ? OuputMessagesFactoryReturn<Value>
+    : Value extends InputMessagesFactory
+      ? OutputMessagesFactory<Value>
+      : never;
 
 type OutputMessagesCategory<Input extends InputMessagesCategory> = { [Key in keyof Input]: OutputMessagesValue<Input[Key]> };
 
@@ -1184,14 +1184,14 @@ export const descriptions = createMessages({
             },
           ]
         : patternType === 'array'
-            ? [
-                {
-                  type: 'log',
-                  category: 'info',
-                  text: 'Did you use `([a]) = 0` instead of `([a] = 0)`?',
-                },
-              ]
-            : [],
+          ? [
+              {
+                type: 'log',
+                category: 'info',
+                text: 'Did you use `([a]) = 0` instead of `([a] = 0)`?',
+              },
+            ]
+          : [],
     }),
     EXPECTED_COMMA_SEPARATOR: (context: string) => ({
       message: `Expected a comma to separate items in ${context}`,

--- a/packages/@romejs/js-formatter/builders/comments.ts
+++ b/packages/@romejs/js-formatter/builders/comments.ts
@@ -58,7 +58,9 @@ function printCommentSeparator(left: AnyNode, right: AnyNode): Token {
   const linesBetween = getLinesBetween(left, right);
   return linesBetween === 0
     ? space
-    : linesBetween === 1 ? hardline : concat([hardline, hardline]);
+    : linesBetween === 1
+      ? hardline
+      : concat([hardline, hardline]);
 }
 
 export function printLeadingComment(node: AnyComment, next: AnyNode): Token {

--- a/packages/@romejs/js-formatter/builders/typescript/TSConditionalType.ts
+++ b/packages/@romejs/js-formatter/builders/typescript/TSConditionalType.ts
@@ -3,9 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- */
-
-import {TSConditionalType} from '@romejs/js-ast';
+ */ import {AnyNode, TSConditionalType} from '@romejs/js-ast';
 import {Builder} from '@romejs/js-formatter';
 import {Token, concat, space} from '../../tokens';
 import {printConditionalExpression} from '../expressions/ConditionalExpression';
@@ -13,6 +11,7 @@ import {printConditionalExpression} from '../expressions/ConditionalExpression';
 export default function TSConditionalType(
   builder: Builder,
   node: TSConditionalType,
+  parent: AnyNode,
 ): Token {
   return printConditionalExpression(
     concat([
@@ -24,5 +23,8 @@ export default function TSConditionalType(
     ]),
     builder.tokenize(node.trueType, node),
     builder.tokenize(node.falseType, node),
+    parent,
+    node.trueType,
+    node.falseType,
   );
 }

--- a/packages/@romejs/js-parser/parser/lval.ts
+++ b/packages/@romejs/js-parser/parser/lval.ts
@@ -1014,7 +1014,9 @@ export function checkLVal(
       description: descriptions.JS_PARSER.INVALID_PARENTEHSIZED_LVAL(
         expr.type === 'BindingObjectPattern'
           ? 'object'
-          : expr.type === 'BindingArrayPattern' ? 'array' : undefined,
+          : expr.type === 'BindingArrayPattern'
+            ? 'array'
+            : undefined,
       ),
       loc: expr.loc,
     });


### PR DESCRIPTION
Nested conditional expressions were indented twice.

This change fixes 2 use cases:
- Over indentation of nested conditional expressions
- Break propagation for nested conditional expressions

**Before:**

```ts
type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
  ? string
  : Type extends Array<AbsoluteFilePath>
      ? Array<string>
      : Type extends AbsoluteFilePathSet
          ? Array<string>
          : Type extends Map<string, any> ? Dict<MapValue<Type>> : Type;
```

**After:**
```ts
type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
  ? string
  : Type extends Array<AbsoluteFilePath>
    ? Array<string>
    : Type extends AbsoluteFilePathSet
      ? Array<string>
      : Type extends Map<string, any>
        ? Dict<MapValue<Type>>
        : Type;
```