### PR TITLE
Clean up Consumer methods

### DIFF
--- a/packages/@romejs/cli-flags/Parser.ts
+++ b/packages/@romejs/cli-flags/Parser.ts
@@ -373,6 +373,7 @@ export default class Parser<T> {
       'generateAutocomplete',
       {
         description: 'Generate a shell autocomplete',
+        inputName: 'shellName',
       },
     ).asStringSetOrVoid(['fish', 'bash']);
     if (generateAutocomplete !== undefined) {
@@ -455,16 +456,12 @@ export default class Parser<T> {
         argCol = `--${argCol}`;
       }
 
-      const {default: defaultValue, allowedValues} = def;
-
       // Add input specifier unless a boolean
       if (def.type !== 'boolean') {
-        // TODO some way to customize this
-        // Property metadata in the consumer is a fine place but we want this to be non-CLI specific
-        let inputName = undefined;
+        let {inputName} = metadata;
 
         if (inputName === undefined) {
-          if (def.type === 'number' || def.type === 'number-range') {
+          if (def.type === 'number') {
             inputName = 'num';
           } else {
             inputName = 'input';
@@ -480,16 +477,17 @@ export default class Parser<T> {
       }
 
       let descCol: string =
-        metadata === undefined || metadata.description === undefined
+        metadata.description === undefined
           ? 'no description found'
           : metadata.description;
 
+      const {default: defaultValue} = def;
       if (defaultValue !== undefined && isDisplayableHelpValue(defaultValue)) {
         descCol += ` (default: ${defaultValue})`;
       }
 
-      if (allowedValues !== undefined) {
-        const displayAllowedValues = allowedValues.filter((item) =>
+      if (def.type === 'string' && def.allowedValues !== undefined) {
+        const displayAllowedValues = def.allowedValues.filter((item) =>
           isDisplayableHelpValue(item)
         );
         if (displayAllowedValues !== undefined) {

--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -40,7 +40,7 @@ type CLIFlags = {
   ragePath: undefined | UnknownFilePath;
   profile: boolean;
   profilePath: undefined | UnknownFilePath;
-  profileTimeout: number;
+  profileTimeout: undefined | number;
   profileSampling: number;
   profileWorkers: boolean;
   temporaryDaemon: boolean;
@@ -111,7 +111,7 @@ export default async function cli() {
             {
               description: 'Stop the profile after the milliseconds specified. When omitted the profile is of the whole command',
             },
-          ).asNumber(0),
+          ).asNumberOrVoid(),
           profileWorkers: c.get(
             'profileWorkers',
             {
@@ -122,6 +122,7 @@ export default async function cli() {
             'profileSampling',
             {
               description: 'Profiler sampling interval in microseconds',
+              inputName: 'microsec',
             },
           ).asNumber(100),
           temporaryDaemon: c.get(
@@ -239,6 +240,7 @@ export default async function cli() {
             'resolverPlatform',
             {
               description: 'Specify the platform for module resolution',
+              inputName: 'platform',
             },
           ).asStringSetOrVoid(PLATFORMS),
           resolverScale: c.get(

--- a/packages/@romejs/consume/types.ts
+++ b/packages/@romejs/consume/types.ts
@@ -37,29 +37,35 @@ export type ConsumeContext = {
 
 export type ConsumePropertyMetadata = {
   description?: string;
+  inputName?: string;
 };
 
 type ConsumePropertyDefinitionBase = {
   objectPath: ConsumePath;
   default: unknown;
   required: boolean;
-  allowedValues?: Array<unknown>;
-  metadata?: ConsumePropertyMetadata;
+  metadata: ConsumePropertyMetadata;
 };
 
-type ConsumePropertyPrimitiveDefinition = ConsumePropertyDefinitionBase & {
-  type: 'string' | 'number' | 'boolean' | 'bigint' | 'date' | 'array' | 'object';
+export type ConsumePropertyPrimitiveDefinition = ConsumePropertyDefinitionBase & {
+  type: 'boolean' | 'bigint' | 'date' | 'array' | 'object';
 };
 
-type ConsumePropertyNumberRangeDefinition = ConsumePropertyDefinitionBase & {
-  type: 'number-range';
-  min: undefined | number;
-  max: undefined | number;
+export type ConsumePropertyStringDefinition = ConsumePropertyDefinitionBase & {
+  type: 'string';
+  allowedValues?: Array<string>;
+};
+
+export type ConsumePropertyNumberDefinition = ConsumePropertyDefinitionBase & {
+  type: 'number';
+  min?: number;
+  max?: number;
 };
 
 export type ConsumePropertyDefinition =
+  | ConsumePropertyStringDefinition
   | ConsumePropertyPrimitiveDefinition
-  | ConsumePropertyNumberRangeDefinition;
+  | ConsumePropertyNumberDefinition;
 
 export type ConsumerOnDefinition = (
   definition: ConsumePropertyDefinition,

--- a/packages/@romejs/core/client/Client.ts
+++ b/packages/@romejs/core/client/Client.ts
@@ -59,7 +59,7 @@ type ClientOptions = {
 
 export type ClientProfileOptions = {
   samplingInterval: number;
-  timeoutInterval: number;
+  timeoutInterval: undefined | number;
   includeWorkers: boolean;
 };
 
@@ -176,7 +176,7 @@ export default class Client {
     // Start a profile timer if one was specified
     let hasProfiled: undefined | Promise<void>;
     let timeout: undefined | NodeJS.Timeout;
-    if (timeoutInterval > 0) {
+    if (timeoutInterval !== undefined) {
       timeout = setTimeout(
         () => {
           hasProfiled = stopProfile(true);

--- a/packages/@romejs/ob1/index.ts
+++ b/packages/@romejs/ob1/index.ts
@@ -65,6 +65,7 @@ export function ob1Get1(x: undefined | Number1): undefined | number {
 }
 
 export function ob1Get(x: UnknownNumber): number;
+export function ob1Get(x: undefined | UnknownNumber): undefined | number;
 export function ob1Get(x: undefined): undefined;
 export function ob1Get(x: undefined | UnknownNumber): undefined | number {
   // @ts-ignore


### PR DESCRIPTION
This PR cleans up a bunch of the `Consumer` methods and adds `inputName`.