### PR TITLE
Grid: Don't output trailing space when next word will overflow

### DIFF
--- a/packages/@romejs/js-compiler/lint/rules/noMultipleSpacesInRegularExpressionLiterals.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/noMultipleSpacesInRegularExpressionLiterals.test.md
@@ -15,7 +15,7 @@
     /foo  bar/
         ^
 
-  ℹ It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead. 
+  ℹ It's hard to visually count the amount of spaces, it's clearer if you use a quantifier instead.
     eg / {3}/
 
   ℹ Recommended fix

--- a/packages/@romejs/js-compiler/lint/rules/noShadowRestrictedNames.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/noShadowRestrictedNames.test.md
@@ -15,7 +15,7 @@
     function NaN() {}
              ^^^
 
-  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named 
+  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named
     after a known global.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -42,7 +42,7 @@ function NaN() {}
     let Set;
         ^^^
 
-  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named 
+  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named
     after a known global.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -97,7 +97,7 @@ function test(JSON) {}
     try {  } catch(Object) {}
                    ^^^^^^
 
-  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named 
+  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named
     after a known global.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/@romejs/string-markup/Grid.ts
+++ b/packages/@romejs/string-markup/Grid.ts
@@ -287,9 +287,9 @@ export default class Grid {
       const word = words[i];
       const isLastWord = i === words.length - 1;
 
-      const willOverflow =
-        this.doesOverflowViewport(ob1Add(this.cursor.column, word.length - 1)) &&
-        !this.doesOverflowViewport(ob1Coerce1(word.length - 1));
+      const willOverflow = this.doesOverflowViewport(
+        ob1Add(this.cursor.column, word.length - 1),
+      );
       if (willOverflow) {
         this.newline();
       }
@@ -298,7 +298,7 @@ export default class Grid {
         this.writeChar(char);
       }
 
-      let ignoreLeadingSpace = false;
+      let ignoreTrailingSpace = false;
 
       // Start of a sentence that was caused by line wrapping
       if (
@@ -306,14 +306,23 @@ export default class Grid {
         this.cursor.column === ob1Number1 &&
         word !== ''
       ) {
-        ignoreLeadingSpace = true;
+        ignoreTrailingSpace = true;
+      }
+
+      // If the next word will cause an overflow then don't print a leading space as it will be pointless
+      const nextWord = words[i + 1];
+      if (
+        nextWord !== undefined &&
+        this.doesOverflowViewport(ob1Add(this.cursor.column, nextWord.length))
+      ) {
+        ignoreTrailingSpace = true;
       }
 
       if (isLastWord) {
-        ignoreLeadingSpace = true;
+        ignoreTrailingSpace = true;
       }
 
-      if (!ignoreLeadingSpace) {
+      if (!ignoreTrailingSpace) {
         this.writeChar(' ');
       }
     }


### PR DESCRIPTION
See snapshot for trailing space removal.