### PR TITLE
Add ul, ol, li markup tags, restrict tags to specific positions

### DIFF
--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -35,6 +35,29 @@ export function createBlessedDiagnosticMessage(
   };
 }
 
+function join(conjunction: string, items: Array<string>): string {
+  if (items.length === 0) {
+    return '';
+  } else if (items.length === 1) {
+    return items[0];
+  } else {
+    return [...items, `${conjunction} ${items.pop()!}`].join(', ');
+  }
+}
+
+// rome-suppress-next-line lint/unusedVariables
+function andJoin(items: Array<string>): string {
+  return join('and', items);
+}
+
+function orJoin(items: Array<string>): string {
+  return join('or', items);
+}
+
+function addEmphasis(items: Array<string>): Array<string> {
+  return items.map((item) => `<emphasis>${item}</emphasis>`);
+}
+
 // rome-suppress-next-line lint/AEciilnnoptxy;
 type InputMessagesFactory = (...params: Array<any>) => DiagnosticMetadataString;
 
@@ -691,11 +714,37 @@ export const descriptions = createMessages({
         },
       ],
     }),
-    INVALID_ATTRIBUTE_NAME_FOR_TAG: (tagName: string, attributeName: string) => ({
-      message: markup`${attributeName} is not a valid attribute name for <${tagName}>`,
+    INVALID_ATTRIBUTE_NAME_FOR_TAG: (
+      tagName: string,
+      attributeName: string,
+      validAttributes: Array<string>,
+    ) => ({
+      message: markup`<emphasis>${attributeName}</emphasis> is not a valid attribute name for <emphasis>${tagName}</emphasis>`,
+      advice: buildSuggestionAdvice(attributeName, validAttributes),
     }),
     UNKNOWN_TAG_NAME: (tagName: string) => ({
       message: markup`Unknown tag name <emphasis>${tagName}</emphasis>`,
+    }),
+    RESTRICTED_CHILD: (
+      tagName: string,
+      allowedParents: Array<string>,
+      gotParentName: string = 'none',
+    ) => ({
+      message: markup`The tag <emphasis>${tagName}</emphasis> should only appear as a child of ${orJoin(
+        addEmphasis(allowedParents),
+      )} not <emphasis>${gotParentName}</emphasis>`,
+    }),
+    RESTRICTED_PARENT: (
+      tagName: string,
+      allowedChildren: Array<string>,
+      gotChildName: string,
+    ) => ({
+      message: markup`The tag <emphasis>${tagName}</emphasis> should only contain the tags ${orJoin(
+        addEmphasis(allowedChildren),
+      )} not <emphasis>${gotChildName}</emphasis>`,
+    }),
+    RESTRICTED_PARENT_TEXT: (tagName: string) => ({
+      message: markup`The tag <emphasis>${tagName}</emphasis> should not contain any text`,
     }),
   },
   // @romejs/path-match

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -45,10 +45,10 @@ function join(conjunction: string, items: Array<string>): string {
   }
 }
 
-// rome-suppress-next-line lint/unusedVariables
 function andJoin(items: Array<string>): string {
   return join('and', items);
 }
+andJoin;
 
 function orJoin(items: Array<string>): string {
   return join('or', items);

--- a/packages/@romejs/string-markup/escape.ts
+++ b/packages/@romejs/string-markup/escape.ts
@@ -66,14 +66,16 @@ export function escapeMarkup(input: string): string {
 export function markupTag(
   tagName: MarkupTagName,
   text: string,
-  attrs?: Dict<string | number | boolean>,
+  attrs?: Dict<undefined | string | number | boolean>,
 ): string {
   let ret = `<${tagName}`;
 
   if (attrs !== undefined) {
     for (const key in attrs) {
       const value = attrs[key];
-      ret += markup` ${key}="${String(value)}"`;
+      if (value !== undefined) {
+        ret += markup` ${key}="${String(value)}"`;
+      }
     }
   }
 

--- a/packages/@romejs/string-markup/types.ts
+++ b/packages/@romejs/string-markup/types.ts
@@ -63,7 +63,10 @@ export type MarkupTagName =
   | 'table'
   | 'tr'
   | 'td'
-  | 'nobr';
+  | 'nobr'
+  | 'ol'
+  | 'ul'
+  | 'li';
 
 export type MarkupFormatFilenameNormalizer = (filename: string) => string;
 


### PR DESCRIPTION
`reporter.list` now just emits `ul`, `ol` and `li` tags. I just want to note again, that the markup we use is not HTML. It looks like HTML for familiarity but we have attribute whitelists, and try to have semantic markup for colored formatting etc.

I also made it enforced in the parser that elements like `li` can only exist inside of `ul`. I extended this to the table elements too.

The new grid rendering allows this to be implemented very easily, with soft line wrapping around bullets. eg.

![Screenshot from 2020-04-29 19-36-40](https://user-images.githubusercontent.com/853712/80670560-101a3a00-8a5c-11ea-87f3-738868bace2d.png)
