### PR TITLE
Allow omitting .test from `rome test` args

### DIFF
--- a/packages/@romejs/core/master/commands/test.ts
+++ b/packages/@romejs/core/master/commands/test.ts
@@ -38,11 +38,10 @@ export default createMasterCommand({
       tryAlternateArg: (path) =>
         path.hasExtension('test')
           ? undefined
-          : path
-              .getParent()
-              .append(
-                `${path.getExtensionlessBasename()}.test${path.getExtensions()}`,
-              ),
+          : path.getParent().append(
+              `${path.getExtensionlessBasename()}.test${path.getExtensions()}`,
+            )
+      ,
       test: (path) => path.hasExtension('test'),
       noun: 'test',
       verb: 'testing',
@@ -51,8 +50,7 @@ export default createMasterCommand({
         {
           type: 'log',
           category: 'info',
-          text:
-            'Searched for files with <emphasis>.test.*</emphasis> file extension',
+          text: 'Searched for files with <emphasis>.test.*</emphasis> file extension',
         },
       ],
       extensions: JS_EXTENSIONS,
@@ -72,14 +70,20 @@ export default createMasterCommand({
       }),
     );
 
-    for (const [path, res] of await bundler.bundleMultiple(Array.from(paths), {
-      deferredSourceMaps: true,
-    })) {
-      tests.set(path.join(), {
-        code: res.entry.js.content,
-        sourceMap: res.entry.sourceMap.map,
-        path,
-      });
+    for (const [path, res] of await bundler.bundleMultiple(
+      Array.from(paths),
+      {
+        deferredSourceMaps: true,
+      },
+    )) {
+      tests.set(
+        path.join(),
+        {
+          code: res.entry.js.content,
+          sourceMap: res.entry.sourceMap.map,
+          path,
+        },
+      );
     }
 
     reporter.info(`Running tests`);

--- a/packages/@romejs/core/master/fs/Resolver.ts
+++ b/packages/@romejs/core/master/fs/Resolver.ts
@@ -37,9 +37,46 @@ function request(
     }
 > {
   return new Promise((resolve) => {
-    const req = https.get(url, (res) => {
-      if (res.statusCode !== 200) {
-        console.log('non-200 return');
+    const req = https.get(
+      url,
+      (res) => {
+        if (res.statusCode !== 200) {
+          console.log('non-200 return');
+          resolve({
+            type: 'FETCH_ERROR',
+            source: undefined,
+            advice: [
+              {
+                type: 'log',
+                category: 'info',
+                text: `<hyperlink target="${url}" /> returned a ${res.statusCode} status code`,
+              },
+            ],
+          });
+          return;
+        }
+
+        let data = '';
+
+        res.on(
+          'data',
+          (chunk) => {
+            data += chunk;
+          },
+        );
+
+        res.on(
+          'end',
+          () => {
+            resolve({type: 'DOWNLOADED', content: data});
+          },
+        );
+      },
+    );
+
+    req.on(
+      'error',
+      (err) => {
         resolve({
           type: 'FETCH_ERROR',
           source: undefined,
@@ -47,37 +84,12 @@ function request(
             {
               type: 'log',
               category: 'info',
-              text: `<hyperlink target="${url}" /> returned a ${res.statusCode} status code`,
+              text: `<hyperlink target="${url}" /> resulted in the error "${err.message}"`,
             },
           ],
         });
-        return;
-      }
-
-      let data = '';
-
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
-
-      res.on('end', () => {
-        resolve({type: 'DOWNLOADED', content: data});
-      });
-    });
-
-    req.on('error', (err) => {
-      resolve({
-        type: 'FETCH_ERROR',
-        source: undefined,
-        advice: [
-          {
-            type: 'log',
-            category: 'info',
-            text: `<hyperlink target="${url}" /> resulted in the error "${err.message}"`,
-          },
-        ],
-      });
-    });
+      },
+    );
   });
 }
 
@@ -205,25 +217,26 @@ function attachExportAliasIfUnresolved(
 
   return {
     ...res,
-    source:
-      location === undefined
-        ? undefined
-        : {
-            location,
-            source: alias.value.join(),
-          },
+    source: location === undefined
+      ? undefined
+      : {
+          location,
+          source: alias.value.join(),
+        },
   };
 }
 
-function getExportsAlias({
-  manifest,
-  relative,
-  platform,
-}: {
-  manifest: Manifest;
-  relative: UnknownFilePath;
-  platform?: Platform;
-}): undefined | ExportAlias {
+function getExportsAlias(
+  {
+    manifest,
+    relative,
+    platform,
+  }: {
+    manifest: Manifest;
+    relative: UnknownFilePath;
+    platform?: Platform;
+  },
+): undefined | ExportAlias {
   if (typeof manifest.exports === 'boolean') {
     return undefined;
   }
@@ -326,12 +339,9 @@ export default class Resolver {
     return res.path;
   }
 
-  async resolveEntry(
-    query: ResolverRemoteQuery,
-    querySource?: ResolverQuerySource,
-  ): Promise<ResolverQueryResponse> {
+  async resolveEntry(query: ResolverRemoteQuery): Promise<ResolverQueryResponse> {
     await this.findProjectFromQuery(query);
-    return this.resolveRemote({...query, entry: true}, querySource);
+    return this.resolveRemote({...query, entry: true});
   }
 
   async resolveAssert(
@@ -502,10 +512,11 @@ export default class Resolver {
     // Check with appended extensions
     if (usesUnknownExtension && !callees.includes('implicitExtension')) {
       for (const ext of IMPLICIT_JS_EXTENSIONS) {
-        yield* this._getFilenameVariants(query, path.addExtension(`.${ext}`), [
-          ...callees,
-          'implicitExtension',
-        ]);
+        yield* this._getFilenameVariants(
+          query,
+          path.addExtension(`.${ext}`),
+          [...callees, 'implicitExtension'],
+        );
       }
     }
 
@@ -520,9 +531,7 @@ export default class Resolver {
         yield* this._getFilenameVariants(
           query,
           path.changeBasename(
-            `${path.getExtensionlessBasename()}@${String(i)}x${
-              path.memoizedExtension
-            }`,
+            `${path.getExtensionlessBasename()}@${String(i)}x${path.memoizedExtension}`,
           ),
           [...callees, 'implicitScale'],
         );
@@ -654,17 +663,13 @@ export default class Resolver {
     moduleName: string,
   ): undefined | ManifestDefinition {
     // Find the project
-    const project = this.master.projectManager.findProjectExisting(
-      query.origin,
-    );
+    const project = this.master.projectManager.findProjectExisting(query.origin);
     if (project === undefined) {
       return undefined;
     }
 
     // Find the package
-    const projects = this.master.projectManager.getHierarchyFromProject(
-      project,
-    );
+    const projects = this.master.projectManager.getHierarchyFromProject(project);
 
     for (const project of projects) {
       const pkg = project.packages.get(moduleName);
@@ -882,9 +887,7 @@ export default class Resolver {
     // Check all parent directories for node_modules
     for (const dir of parentDirectories) {
       const modulePath = dir.append(NODE_MODULES).append(moduleName);
-      const manifestDef = this.master.memoryFs.getManifestDefinition(
-        modulePath,
-      );
+      const manifestDef = this.master.memoryFs.getManifestDefinition(modulePath);
       if (manifestDef !== undefined) {
         return this.resolveManifest(query, manifestDef, moduleNameParts);
       }


### PR DESCRIPTION
I found myself running commands like:

```
$ ./scripts/dev-rome test packages/@romejs/cli-flags/Parser.ts
```

Note the lack of `.test.ts`. With this PR, we will alternatively try arguments without `.test.ts` with the added extension. This would also allow something like "Run tests for this file" in an IDE where an editor can just send us the source file path and we deal with the resolution.