### PR TITLE
Don't apply formatting or fixes when running `lint --review`

### DIFF
--- a/packages/@romejs/core/master/linter/Linter.ts
+++ b/packages/@romejs/core/master/linter/Linter.ts
@@ -401,8 +401,8 @@ export default class Linter {
   }
 
   shouldSave(): boolean {
-    const {save, hasDecisions} = this.options;
-    return save || hasDecisions || this.shouldApplyFixes();
+    const {save, hasDecisions, formatOnly} = this.options;
+    return save || hasDecisions || formatOnly;
   }
 
   getFileArgOptions(): MasterRequestGetFilesOptions {

--- a/packages/@romejs/core/master/linter/Linter.ts
+++ b/packages/@romejs/core/master/linter/Linter.ts
@@ -160,8 +160,9 @@ class LintRunner {
     let savedCount = 0;
     const {master} = this.request;
 
-    const {compilerOptionsPerFile, hasDecisions, formatOnly} = this.options;
+    const {compilerOptionsPerFile, hasDecisions} = this.options;
     const shouldSave = this.linter.shouldSave();
+    const shouldApplyFixes = this.linter.shouldApplyFixes();
 
     const queue: WorkerQueue<void> = new WorkerQueue(master);
 
@@ -194,7 +195,7 @@ class LintRunner {
         path,
         {
           save: shouldSave,
-          applyFixes: !formatOnly,
+          applyFixes: shouldApplyFixes,
           compilerOptions,
         },
       );
@@ -394,14 +395,14 @@ export default class Linter {
   request: MasterRequest;
   options: LinterOptions;
 
+  shouldApplyFixes(): boolean {
+    const {formatOnly} = this.options;
+    return !formatOnly;
+  }
+
   shouldSave(): boolean {
-    const {save, hasDecisions, formatOnly} = this.options;
-    return (
-      save ||
-      hasDecisions ||
-      formatOnly ||
-      this.request.query.requestFlags.review
-    );
+    const {save, hasDecisions} = this.options;
+    return save || hasDecisions || this.shouldApplyFixes();
   }
 
   getFileArgOptions(): MasterRequestGetFilesOptions {


### PR DESCRIPTION
Previously when running `rome lint --review` we would apply recommended fixes and formatting. The main motivation behind this was that there was no way for us to apply fixes to a file that had no lint errors but only pending formatting changes. That is no longer relevant because:

1. There's the `--format` flag to only apply formatting
2. The "pending fixes" diagnostic now has an action that will be displayed

cc @hzoo