### PR TITLE
Add global lint decisions

### DIFF
--- a/packages/@romejs/cli-reporter/types.ts
+++ b/packages/@romejs/cli-reporter/types.ts
@@ -13,10 +13,10 @@ export type SelectOption = {
 };
 
 export type SelectOptions = {
-  [key: string]: SelectOption;
+  [key: string]: undefined | SelectOption;
 };
 
-export type SelectArguments<Options> = {
+export type SelectArguments<Options extends SelectOptions> = {
   options: Options;
   defaults?: Array<keyof Options>;
   radio?: boolean;

--- a/packages/@romejs/core/client/review.ts
+++ b/packages/@romejs/core/client/review.ts
@@ -19,6 +19,7 @@ import {Dict} from '@romejs/typescript-helpers';
 import {EMPTY_SUCCESS_RESPONSE} from '../master/MasterRequest';
 
 type State = {
+  initial: boolean;
   seen: Set<string>;
   resolvedCount: number;
 };
@@ -27,8 +28,16 @@ async function check(
   req: ClientRequest,
   state: State,
 ): Promise<MasterQueryResponse> {
-  const {client} = req;
-  const {reporter} = client;
+  const {reporter} = req.client;
+
+  reporter.clearScreen();
+
+  if (state.initial) {
+    reporter.info('Fetching initial diagnostics');
+    state.initial = false;
+  } else {
+    reporter.info('Updating diagnostics');
+  }
 
   const res = await req.fork({
     ...req.query,
@@ -61,11 +70,30 @@ async function check(
     return res;
   }
 
+  return await ask(diag, req, state, false);
+}
+
+async function ask(
+  diag: Diagnostic,
+  req: ClientRequest,
+  state: State,
+  more: boolean,
+): Promise<MasterQueryResponse> {
+  const {client} = req;
+  const {reporter} = client;
+  reporter.clearScreen();
+
   // Extract actions and remove them from the diagnostic
   let {advice = []} = diag.description;
+  let hasExtraOptions = false;
   const actions: Array<DiagnosticAdviceAction> = [];
   for (const item of advice) {
     if (item.type === 'action') {
+      if (item.extra === true && !more) {
+        hasExtraOptions = true;
+        continue;
+      }
+
       actions.push(item);
     }
   }
@@ -100,6 +128,7 @@ async function check(
   const options: {
     ignore: SelectOption;
     exit: SelectOption;
+    more?: SelectOption;
   } = {
     ignore: {
       label: 'Do nothing',
@@ -112,7 +141,13 @@ async function check(
     },
   };
 
-  reporter.clearScreen();
+  if (!more && hasExtraOptions) {
+    options.more = {
+      label: 'More options...',
+      shortcut: 'm',
+    };
+  }
+
   printDiagnostics({
     diagnostics: [diag],
     suppressions: [],
@@ -128,6 +163,10 @@ async function check(
       options,
     },
   );
+
+  if (answer === 'more') {
+    return await ask(diag, req, state, true);
+  }
 
   if (answer === 'ignore') {
     return await check(req, state);
@@ -169,15 +208,17 @@ export default async function review(
 ): Promise<MasterQueryResponse> {
   const {reporter} = req.client;
   const state: State = {
+    initial: true,
     seen: new Set(),
     resolvedCount: 0,
   };
   const res = await check(req, state);
 
+  reporter.clearScreen();
+
   if (state.seen.size === 0) {
     reporter.success('Nothing to review!');
   } else {
-    reporter.clearScreen();
     if (res.type === 'DIAGNOSTICS') {
       printDiagnostics({
         diagnostics: res.diagnostics,

--- a/packages/@romejs/core/master/commands/lint.ts
+++ b/packages/@romejs/core/master/commands/lint.ts
@@ -6,10 +6,16 @@
  */
 
 import {MasterRequest} from '@romejs/core';
-import Linter, {LinterOptions} from '../linter/Linter';
+import Linter, {
+  LinterCompilerOptionsPerFile,
+  LinterOptions,
+} from '../linter/Linter';
 import {markup} from '@romejs/string-markup';
 import {createMasterCommand} from '../commands';
-import {parseDecisionStrings} from '@romejs/js-compiler';
+import {
+  LintCompilerOptionsDecisions,
+  parseDecisionStrings,
+} from '@romejs/js-compiler';
 import {Consumer} from '@romejs/consume';
 import {commandCategories} from '@romejs/core/common/commands';
 
@@ -39,10 +45,11 @@ export default createMasterCommand<Flags>({
   async callback(req: MasterRequest, flags: Flags): Promise<void> {
     const {reporter} = req;
 
-    let compilerOptionsPerFile: LinterOptions['compilerOptionsPerFile'] = {};
+    let lintCompilerOptionsPerFile: LinterCompilerOptionsPerFile = {};
+    let globalDecisions: LintCompilerOptionsDecisions = [];
     const {decisions} = flags;
     if (decisions !== undefined) {
-      compilerOptionsPerFile = parseDecisionStrings(
+      ({lintCompilerOptionsPerFile, globalDecisions} = parseDecisionStrings(
         decisions,
         req.client.flags.cwd,
         (description) => {
@@ -51,7 +58,7 @@ export default createMasterCommand<Flags>({
             target: {type: 'flag', key: 'decisions'},
           });
         },
-      );
+      ));
     }
 
     // Look up arguments manually in vsc if we were passed a changes branch
@@ -75,7 +82,8 @@ export default createMasterCommand<Flags>({
 
     const opts: LinterOptions = {
       hasDecisions: flags.decisions.length > 0,
-      compilerOptionsPerFile,
+      lintCompilerOptionsPerFile,
+      globalDecisions,
       save: flags.save,
       formatOnly: flags.formatOnly,
       args,

--- a/packages/@romejs/core/master/linter/Linter.ts
+++ b/packages/@romejs/core/master/linter/Linter.ts
@@ -170,7 +170,7 @@ class LintRunner {
       hasDecisions,
     } = this.options;
     const shouldSave = this.linter.shouldSave();
-    const shouldApplyFixes = this.linter.shouldApplyFixes();
+    const shouldApplyFixes = !this.linter.shouldOnlyFormat();
 
     const queue: WorkerQueue<void> = new WorkerQueue(master);
 
@@ -412,14 +412,15 @@ export default class Linter {
   request: MasterRequest;
   options: LinterOptions;
 
-  shouldApplyFixes(): boolean {
+  shouldOnlyFormat(): boolean {
     const {formatOnly} = this.options;
-    return !formatOnly;
+    const {review} = this.request.query.requestFlags;
+    return formatOnly || review;
   }
 
   shouldSave(): boolean {
-    const {save, hasDecisions, formatOnly} = this.options;
-    return save || hasDecisions || formatOnly;
+    const {save, hasDecisions} = this.options;
+    return save || hasDecisions || this.shouldOnlyFormat();
   }
 
   getFileArgOptions(): MasterRequestGetFilesOptions {

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -291,7 +291,7 @@ export const descriptions = createMessages({
       formatted: string,
     ) => ({
       category: 'lint/pendingFixes',
-      message: 'Pending autofixes and formatting',
+      message: 'Pending formatting and recommended autofixes',
       advice: [
         {
           type: 'diff',
@@ -299,23 +299,25 @@ export const descriptions = createMessages({
         },
         ({
           type: 'action',
-          hidden: true,
           command: 'lint',
-          instruction: 'To format this file without any fixes run',
-          noun: 'Format file',
+          shortcut: 'f',
+          instruction: 'To apply fixes and formatting run',
+          noun: 'Apply fixes and format',
           args: [relativeFilename],
           commandFlags: {
-            formatOnly: true,
+            save: true,
           },
         } as DiagnosticAdviceAction),
         ({
           type: 'action',
+          hidden: true,
           command: 'lint',
-          instruction: 'To format and apply recommended fixes run',
-          noun: 'Fix file',
+          shortcut: 'o',
+          instruction: 'To format this file without any fixes run',
+          noun: 'Only format',
           args: [relativeFilename],
           commandFlags: {
-            save: true,
+            format: true,
           },
         } as DiagnosticAdviceAction),
       ],

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -131,6 +131,7 @@ export type DiagnosticAdviceInspect = {
 export type DiagnosticAdviceAction = {
   type: 'action';
   hidden?: boolean;
+  extra?: boolean;
   shortcut?: string;
   instruction: string;
   noun: string;

--- a/packages/@romejs/js-compiler/lib/CompilerContext.ts
+++ b/packages/@romejs/js-compiler/lib/CompilerContext.ts
@@ -55,6 +55,8 @@ import {FileReference} from '@romejs/core';
 import {DEFAULT_PROJECT_CONFIG} from '@romejs/project';
 import {
   buildLintDecisionAdviceAction,
+  buildLintDecisionGlobalString,
+  buildLintDecisionString,
   deriveDecisionPositionKey,
 } from '../lint/decisions';
 
@@ -316,16 +318,27 @@ export default class CompilerContext {
       } else {
         advice.push(
           buildLintDecisionAdviceAction({
+            filename: this.displayFilename,
+            decision: buildLintDecisionString({
+              action: 'fix',
+              filename: this.displayFilename,
+              category,
+              start: loc.start,
+            }),
+            shortcut: 'f',
             noun: 'Apply fix',
             instruction: 'To apply this fix run',
-            filename: this.displayFilename,
-            action: 'fix',
-            category,
-            start: loc.start,
           }),
         );
 
-        // TODO add fix all with this category option
+        advice.push(
+          buildLintDecisionAdviceAction({
+            extra: true,
+            noun: 'Apply fix for ALL files with this category',
+            instruction: 'To apply fix for ALL files with this category run',
+            decision: buildLintDecisionGlobalString('fix', category),
+          }),
+        );
       }
     }
 
@@ -391,10 +404,13 @@ export default class CompilerContext {
               shortcut: String(num),
               instruction: 'To apply this fix run',
               filename: this.displayFilename,
-              action: 'fix',
-              category,
-              start: loc.start,
-              id: index,
+              decision: buildLintDecisionString({
+                filename: this.displayFilename,
+                action: 'fix',
+                category,
+                start: loc.start,
+                id: index,
+              }),
             }),
           );
         }
@@ -449,13 +465,23 @@ export default class CompilerContext {
           shortcut: 's',
           instruction: 'To suppress this error run',
           filename: this.displayFilename,
-          action: 'suppress',
-          category,
-          start: loc.start,
+          decision: buildLintDecisionString({
+            filename: this.displayFilename,
+            action: 'suppress',
+            category,
+            start: loc.start,
+          }),
         }),
       );
 
-      // TODO add suppress all action
+      advice.push(
+        buildLintDecisionAdviceAction({
+          extra: true,
+          noun: 'Add suppression comments for ALL files with this category',
+          instruction: 'To add suppression comments for ALL files with this category run',
+          decision: buildLintDecisionGlobalString('suppress', category),
+        }),
+      );
     }
 
     const {marker, ...diag} = contextDiag;

--- a/packages/@romejs/js-compiler/lint/decisions.ts
+++ b/packages/@romejs/js-compiler/lint/decisions.ts
@@ -10,50 +10,104 @@ import {
   DiagnosticAdviceAction,
   DiagnosticCategory,
   DiagnosticDescriptionOptionalCategory,
+  DiagnosticLocation,
   descriptions,
 } from '@romejs/diagnostics';
-import {LintCompilerOptionsDecision} from '../types';
+import {
+  LintCompilerOptionsDecision,
+  LintCompilerOptionsDecisionAction,
+} from '../types';
 import {ob1Get0, ob1Get1} from '@romejs/ob1';
 import {AbsoluteFilePath} from '@romejs/path';
-import {LinterOptions} from '@romejs/core/master/linter/Linter';
+import {LinterCompilerOptionsPerFile} from '@romejs/core/master/linter/Linter';
 import {escapeSplit} from '@romejs/string-utils';
+
+type UnexpectedDecision = (
+  description: DiagnosticDescriptionOptionalCategory,
+) => void;
+
+function validateAction(
+  raw: string,
+  unexpected: UnexpectedDecision,
+): undefined | LintCompilerOptionsDecisionAction {
+  if (raw === 'fix' || raw === 'suppress' || raw === 'ignore') {
+    return raw;
+  } else {
+    unexpected(descriptions.LINT_COMMAND.INVALID_DECISION_ACTION(raw));
+    return undefined;
+  }
+}
+
+export function deriveDecisionPositionKey(
+  action: LintCompilerOptionsDecisionAction,
+  loc: undefined | DiagnosticLocation,
+): undefined | string {
+  if (loc === undefined) {
+    return undefined;
+  }
+
+  const {start} = loc;
+  if (start === undefined) {
+    return undefined;
+  }
+
+  if (action === 'suppress') {
+    return `${ob1Get1(start.line)}`;
+  } else {
+    return `${ob1Get1(start.line)}:${ob1Get0(start.column)}`;
+  }
+}
 
 export function parseDecisionStrings(
   decisions: Array<string>,
   cwd: AbsoluteFilePath,
-  unexpected: (description: DiagnosticDescriptionOptionalCategory) => void,
-): LinterOptions['compilerOptionsPerFile'] {
-  const compilerOptionsPerFile: LinterOptions['compilerOptionsPerFile'] = {};
+  unexpected: UnexpectedDecision,
+): {
+  lintCompilerOptionsPerFile: LinterCompilerOptionsPerFile;
+  globalDecisions: Array<LintCompilerOptionsDecision>;
+} {
+  const lintCompilerOptionsPerFile: LinterCompilerOptionsPerFile = {};
+  const globalDecisions: Array<LintCompilerOptionsDecision> = [];
 
-  for (let i = 0; i < decisions.length; i++) {
-    const segment = decisions[i];
-    const parts = escapeSplit(segment, '-');
+  function parseGlobalDecision(parts: Array<string>, i: number) {
+    if (parts.length < 3) {
+      unexpected(descriptions.LINT_COMMAND.INVALID_DECISION_PART_COUNT(i));
+    }
 
+    const [rawAction, rawCategory] = parts;
+
+    const action = validateAction(rawAction, unexpected);
+    if (action === undefined) {
+      return;
+    }
+
+    const category = (rawCategory as DiagnosticCategory);
+    globalDecisions.push({category, action});
+  }
+
+  function parseLineDecision(parts: Array<string>, i: number) {
     if (parts.length < 4) {
       unexpected(descriptions.LINT_COMMAND.INVALID_DECISION_PART_COUNT(i));
     }
 
     const [rawAction, rawCategory, rawFilename, pos, id] = parts;
 
-    if (
-      rawAction !== 'fix' &&
-      rawAction !== 'suppress' &&
-      rawAction !== 'ignore'
-    ) {
-      unexpected(descriptions.LINT_COMMAND.INVALID_DECISION_ACTION(rawAction));
-      break;
+    const action = validateAction(rawAction, unexpected);
+    if (action === undefined) {
+      return;
     }
 
-    const action = rawAction;
     const category = (rawCategory as DiagnosticCategory);
     const resolvedFilename = cwd.resolve(rawFilename).join();
 
-    let compilerOptions = compilerOptionsPerFile[resolvedFilename];
+    let compilerOptions = lintCompilerOptionsPerFile[resolvedFilename];
     if (compilerOptions === undefined) {
       compilerOptions = {
+        hasDecisions: true,
+        globalDecisions: [],
         decisionsByPosition: {},
       };
-      compilerOptionsPerFile[resolvedFilename] = compilerOptions;
+      lintCompilerOptionsPerFile[resolvedFilename] = compilerOptions;
     }
 
     let decisionsForPosition = compilerOptions.decisionsByPosition[pos];
@@ -69,7 +123,18 @@ export function parseDecisionStrings(
     });
   }
 
-  return compilerOptionsPerFile;
+  for (let i = 0; i < decisions.length; i++) {
+    const segment = decisions[i];
+    const parts = escapeSplit(segment, '-');
+
+    if (parts[0] === 'global') {
+      parseGlobalDecision(parts, i);
+    } else {
+      parseLineDecision(parts, i);
+    }
+  }
+
+  return {lintCompilerOptionsPerFile, globalDecisions};
 }
 
 export function buildLintDecisionAdviceAction(
@@ -95,10 +160,7 @@ export function buildLintDecisionAdviceAction(
 ): DiagnosticAdviceAction {
   const escapedFilename = filename.replace(/-/, '\\-');
 
-  const pos =
-    action === 'suppress'
-      ? `${ob1Get1(start.line)}`
-      : `${ob1Get1(start.line)}:${ob1Get0(start.column)}`;
+  const pos = deriveDecisionPositionKey(action, {start});
 
   const parts = [action, category, escapedFilename, pos];
 

--- a/packages/@romejs/js-compiler/lint/suppressions.ts
+++ b/packages/@romejs/js-compiler/lint/suppressions.ts
@@ -27,8 +27,7 @@ function buildSuppressionCommentValue(categories: Set<string>): string {
 }
 
 export function addSuppressions(context: CompilerContext, ast: Program): Program {
-  const decisionsByPosition = context.getLintDecisions();
-  if (decisionsByPosition === undefined) {
+  if (!context.hasLintDecisions()) {
     return ast;
   }
 
@@ -124,8 +123,8 @@ export function addSuppressions(context: CompilerContext, ast: Program): Program
           return node;
         }
 
-        const decisions = decisionsByPosition[ob1Get1(line)];
-        if (decisions === undefined) {
+        const decisions = context.getLintDecisions(String(ob1Get1(line)));
+        if (decisions.length === 0) {
           return node;
         }
 

--- a/packages/@romejs/js-compiler/types.ts
+++ b/packages/@romejs/js-compiler/types.ts
@@ -96,13 +96,17 @@ export type BundleCompileOptions = {
 };
 
 export type LintCompilerOptions = {
+  hasDecisions?: boolean;
+  globalDecisions?: LintCompilerOptionsDecisions;
   decisionsByPosition?: Dict<LintCompilerOptionsDecisions>;
 };
 
 export type LintCompilerOptionsDecisions = Array<LintCompilerOptionsDecision>;
 
+export type LintCompilerOptionsDecisionAction = 'suppress' | 'fix' | 'ignore';
+
 export type LintCompilerOptionsDecision = {
-  action: 'suppress' | 'fix' | 'ignore';
+  action: LintCompilerOptionsDecisionAction;
   category: DiagnosticCategory;
   id?: number;
 };


### PR DESCRIPTION
This PR allows you to run:

```
$ rome lint --decisions global:suppress:lint/camelCase
```

This is different to the way other lint decisions are specified as it's not bound to a file.

This will allow us to add a diagnostic action that says "Apply this fix to all files" or "Apply this fix to all occurrences in this file". The wording will be tricky and I'm not sure how many options we'll want to have.

Note that it's unlikely that a user will actually be running this command. It will be done under the hood by `--review`.

In the process I cleaned up a lot of the lint decision code that powers the selective fixes/suppressions.

The only remaining part of this PR is actually adding the actions which is easy, and then testing it.