### PR TITLE
Warn on file changes while reviewing a diagnostic

### DIFF
--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -37,6 +37,7 @@ import {
 } from '@romejs/string-markup/types';
 import select from './select';
 import {MarkupLinesAndWidth} from '@romejs/string-markup/format';
+import {onKeypress} from './util';
 
 type ListOptions = {
   reverse?: boolean;
@@ -533,6 +534,23 @@ export default class Reporter {
       },
     );
     return answer === 'yes';
+  }
+
+  async confirm(message: string = 'Press any key to continue'): Promise<void> {
+    this.logAll(`<dim>${message}</dim>`, {newline: false});
+
+    await new Promise((resolve) => {
+      const keypress = onKeypress(
+        this,
+        () => {
+          keypress.finish();
+          resolve();
+        },
+      );
+    });
+
+    // Newline
+    this.logAll('');
   }
 
   async radio<Options extends SelectOptions>(


### PR DESCRIPTION
Previously, when reviewing a diagnostic and a decision was made, if the file was outdated then the command would most likely be out of date. Lines may have changed, and we could insert suppression comments in the wrong places.

Now there's a warning that appears that waits for you acknowledge the message before asking you to try again.

Under the hood this uses the same outdated detection logic that's inside of the diagnostic printer. Between when a diagnostic has been emitted and we actually print it to the console it may have been changed, and we print a warning. Instead we just refresh that internal outdated map and check again. This way we'll be reusing the existing `dependencies` field on a diagnostic and it will work even with any future changes.

![Screenshot from 2020-04-30 20-37-14](https://user-images.githubusercontent.com/853712/80780440-cd239980-8b23-11ea-8969-c1fa28545228.png)
