### PR TITLE
 Clean up suppressions and add rome-disable-next-statement 

### DIFF
--- a/packages/@romejs-integration/vscode/src/extension.ts
+++ b/packages/@romejs-integration/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient';
-// rome-suppress-next-line resolver/notFound
+// rome-disable-next-line resolver/notFound
 import * as vscode from 'vscode';
 import path = require('path');
 

--- a/packages/@romejs-integration/vscode/src/extension.ts
+++ b/packages/@romejs-integration/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient';
-// rome-disable-next-line resolver/notFound
+// rome-ignore-next-line resolver/notFound
 import * as vscode from 'vscode';
 import path = require('path');
 

--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -46,7 +46,7 @@ type ListOptions = {
   start?: number;
 };
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 type WrapperFactory = <T extends (...args: Array<any>) => any>(callback: T) => T;
 
 export type ReporterOptions = {

--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -46,7 +46,7 @@ type ListOptions = {
   start?: number;
 };
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 type WrapperFactory = <T extends (...args: Array<any>) => any>(callback: T) => T;
 
 export type ReporterOptions = {

--- a/packages/@romejs/codec-js-manifest/convert.ts
+++ b/packages/@romejs/codec-js-manifest/convert.ts
@@ -32,7 +32,7 @@ export function convertManifestToJSON(manifest: Manifest): JSONManifest {
     main: manifest.main,
     // TODO we now support fallbacks which means manifest.exports is lossy
     //exports: exportsToObject(manifest.exports),
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     exports: (manifest.raw.exports as any),
     author: manifest.author,
     contributors: manifest.contributors,

--- a/packages/@romejs/codec-js-manifest/convert.ts
+++ b/packages/@romejs/codec-js-manifest/convert.ts
@@ -32,7 +32,7 @@ export function convertManifestToJSON(manifest: Manifest): JSONManifest {
     main: manifest.main,
     // TODO we now support fallbacks which means manifest.exports is lossy
     //exports: exportsToObject(manifest.exports),
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     exports: (manifest.raw.exports as any),
     author: manifest.author,
     contributors: manifest.contributors,

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -878,7 +878,7 @@ export default class Consumer {
       this.unexpected(
         descriptions.CONSUME.INVALID_STRING_SET_VALUE(
           value,
-          // rome-suppress-next-line lint/noExplicitAny
+          // rome-disable-next-line lint/noExplicitAny
           ((validValues as any) as Array<string>),
         ),
         {
@@ -1201,7 +1201,7 @@ export default class Consumer {
     return this.value;
   }
 
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   asAny(): any {
     return this.value;
   }

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -878,7 +878,7 @@ export default class Consumer {
       this.unexpected(
         descriptions.CONSUME.INVALID_STRING_SET_VALUE(
           value,
-          // rome-disable-next-line lint/noExplicitAny
+          // rome-ignore-next-line lint/noExplicitAny
           ((validValues as any) as Array<string>),
         ),
         {
@@ -1201,7 +1201,7 @@ export default class Consumer {
     return this.value;
   }
 
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   asAny(): any {
     return this.value;
   }

--- a/packages/@romejs/core/client/ClientRequest.ts
+++ b/packages/@romejs/core/client/ClientRequest.ts
@@ -71,7 +71,7 @@ export default class ClientRequest {
   }
 
   async initFromLocal(
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     localCommand: LocalCommand<any>,
   ): Promise<MasterQueryResponse> {
     const {query} = this;

--- a/packages/@romejs/core/client/ClientRequest.ts
+++ b/packages/@romejs/core/client/ClientRequest.ts
@@ -71,7 +71,7 @@ export default class ClientRequest {
   }
 
   async initFromLocal(
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     localCommand: LocalCommand<any>,
   ): Promise<MasterQueryResponse> {
     const {query} = this;

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -33,7 +33,7 @@ export function createLocalCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export const localCommands: Map<string, LocalCommand<any>> = new Map();
 localCommands.set('init', init);
 localCommands.set('start', start);

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -33,7 +33,7 @@ export function createLocalCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export const localCommands: Map<string, LocalCommand<any>> = new Map();
 localCommands.set('init', init);
 localCommands.set('start', start);

--- a/packages/@romejs/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/WorkerBridge.ts
@@ -264,7 +264,7 @@ export default class WorkerBridge extends Bridge {
         hydrate(err, data) {
           return new DiagnosticsError(
             String(err.message),
-            // rome-suppress-next-line lint/noExplicitAny
+            // rome-disable-next-line lint/noExplicitAny
             (data.diagnostics as any),
           );
         },

--- a/packages/@romejs/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/WorkerBridge.ts
@@ -264,7 +264,7 @@ export default class WorkerBridge extends Bridge {
         hydrate(err, data) {
           return new DiagnosticsError(
             String(err.message),
-            // rome-disable-next-line lint/noExplicitAny
+            // rome-ignore-next-line lint/noExplicitAny
             (data.diagnostics as any),
           );
         },

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -301,9 +301,9 @@ export default class Master {
     process.exit();
   }
 
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   wrapFatal<T extends (...args: Array<any>) => any>(callback: T): T {
-    return ((// rome-disable-next-line lint/noExplicitAny
+    return ((// rome-ignore-next-line lint/noExplicitAny
     (...args: Array<any>): any => {
       try {
         const res = callback(...args);

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -301,9 +301,9 @@ export default class Master {
     process.exit();
   }
 
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   wrapFatal<T extends (...args: Array<any>) => any>(callback: T): T {
-    return ((// rome-suppress-next-line lint/noExplicitAny
+    return ((// rome-disable-next-line lint/noExplicitAny
     (...args: Array<any>): any => {
       try {
         const res = callback(...args);

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -344,7 +344,7 @@ export default class Bundler {
     }
 
     // TODO `{type: "module"}` will always fail since we've produced CJS bundles
-    // rome-suppress-next-line lint/noDelete
+    // rome-disable-next-line lint/noDelete
     delete newManifest.type;
 
     return newManifest;

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -344,7 +344,7 @@ export default class Bundler {
     }
 
     // TODO `{type: "module"}` will always fail since we've produced CJS bundles
-    // rome-disable-next-line lint/noDelete
+    // rome-ignore-next-line lint/noDelete
     delete newManifest.type;
 
     return newManifest;

--- a/packages/@romejs/core/master/commands.ts
+++ b/packages/@romejs/core/master/commands.ts
@@ -49,7 +49,7 @@ export function createMasterCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export const masterCommands: Map<string, MasterCommand<any>> = new Map();
 masterCommands.set('test', test);
 masterCommands.set('lint', lint);

--- a/packages/@romejs/core/master/commands.ts
+++ b/packages/@romejs/core/master/commands.ts
@@ -49,7 +49,7 @@ export function createMasterCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export const masterCommands: Map<string, MasterCommand<any>> = new Map();
 masterCommands.set('test', test);
 masterCommands.set('lint', lint);

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -322,9 +322,9 @@ async function createWatchmanWatcher(
         return;
       }
 
-      // rome-suppress-next-line lint/noExplicitAny
+      // rome-disable-next-line lint/noExplicitAny
       const dirs: Array<[AbsoluteFilePath, any]> = [];
-      // rome-suppress-next-line lint/noExplicitAny
+      // rome-disable-next-line lint/noExplicitAny
       const files: Array<[AbsoluteFilePath, any]> = [];
 
       for (const file of data.files) {
@@ -847,7 +847,7 @@ export default class MemoryFileSystem {
 
       const manifest = this.getManifest(packagePath);
 
-      // rome-suppress-next-line lint/camelCase
+      // rome-disable-next-line lint/camelCase
       if ((manifest?.raw)?.haste_commonjs === true) {
         return false;
       }

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -322,9 +322,9 @@ async function createWatchmanWatcher(
         return;
       }
 
-      // rome-disable-next-line lint/noExplicitAny
+      // rome-ignore-next-line lint/noExplicitAny
       const dirs: Array<[AbsoluteFilePath, any]> = [];
-      // rome-disable-next-line lint/noExplicitAny
+      // rome-ignore-next-line lint/noExplicitAny
       const files: Array<[AbsoluteFilePath, any]> = [];
 
       for (const file of data.files) {
@@ -847,7 +847,7 @@ export default class MemoryFileSystem {
 
       const manifest = this.getManifest(packagePath);
 
-      // rome-disable-next-line lint/camelCase
+      // rome-ignore-next-line lint/camelCase
       if ((manifest?.raw)?.haste_commonjs === true) {
         return false;
       }

--- a/packages/@romejs/core/master/testing/TestMasterRunner.ts
+++ b/packages/@romejs/core/master/testing/TestMasterRunner.ts
@@ -867,7 +867,7 @@ export default class TestMasterRunner {
       if (inline) {
         noun = `inline ${noun}`;
       }
-      parts.push(`<number emphasis>${count}</emphasis> ${noun}`);
+      parts.push(`<number emphasis>${count}</number> ${noun}`);
     }
 
     reporter.success(parts.join(', '));

--- a/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
+++ b/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
@@ -371,8 +371,8 @@ export default class DiagnosticsProcessor {
       }
 
       diagnostics.push({
-        location: suppression.loc,
-        description: descriptions.SUPPRESSIONS.UNUSED,
+        location: suppression.commentLocation,
+        description: descriptions.SUPPRESSIONS.UNUSED(suppression),
       });
     }
 

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -92,6 +92,7 @@ export type DiagnosticCategory =
   | 'suppressions/duplicate'
   | 'suppressions/incorrectPrefix'
   | 'suppressions/missingSpace'
+  | 'suppressions/missingTarget'
   | 'suppressions/unused'
   | 'tests/cancelled'
   | 'tests/disabled'

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -11,6 +11,7 @@ import {
   DiagnosticBlessedMessage,
   DiagnosticDescription,
   DiagnosticLocation,
+  DiagnosticSuppression,
 } from './types';
 import {escapeMarkup, markup} from '@romejs/string-markup';
 import stringDiff from '@romejs/string-diff';
@@ -781,9 +782,30 @@ export const descriptions = createMessages({
     }),
   },
   SUPPRESSIONS: {
-    UNUSED: {
-      message: 'Unused suppression. Did not hide any errors.',
-      category: 'suppressions/unused',
+    UNUSED: (suppression: DiagnosticSuppression) => {
+      let description = {
+        next: 'next line',
+        current: 'current line',
+        statement: 'next statement',
+      }[suppression.type];
+
+      if (suppression.startLine === suppression.endLine) {
+        description += ` line ${suppression.startLine}`;
+      } else {
+        description += ` lines ${suppression.startLine}-${suppression.endLine}`;
+      }
+
+      return {
+        message: 'Unused suppression. Did not hide any errors.',
+        category: 'suppressions/unused',
+        advice: [
+          {
+            type: 'log',
+            category: 'info',
+            text: `This suppression prefixes hides the <emphasis>${description}</emphasis>`,
+          },
+        ],
+      };
     },
     MISSING_SPACE: {
       category: 'suppressions/missingSpace',

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -58,7 +58,7 @@ function addEmphasis(items: Array<string>): Array<string> {
   return items.map((item) => `<emphasis>${item}</emphasis>`);
 }
 
-// rome-suppress-next-line lint/AEciilnnoptxy;
+// rome-disable-next-line lint/AEciilnnoptxy;
 type InputMessagesFactory = (...params: Array<any>) => DiagnosticMetadataString;
 
 type InputMessagesCategory = {
@@ -102,11 +102,11 @@ type OutputMessages<Input extends InputMessages> = {
 function createMessages<Input extends InputMessages>(
   messages: Input,
 ): OutputMessages<Input> {
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   const out: OutputMessages<Input> = ({} as any);
 
   for (const categoryName in messages) {
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     const category: OutputMessagesCategory<any> = {};
     out[categoryName] = category;
 
@@ -119,7 +119,7 @@ function createMessages<Input extends InputMessages>(
           message: createBlessedDiagnosticMessage(value),
         };
       } else if (typeof value === 'function') {
-        // rome-suppress-next-line lint/noExplicitAny
+        // rome-disable-next-line lint/noExplicitAny
         const callback: InputMessagesFactory = (value as any);
 
         category[key] = function(...params) {
@@ -130,7 +130,7 @@ function createMessages<Input extends InputMessages>(
           };
         };
       } else {
-        // rome-suppress-next-line lint/noExplicitAny
+        // rome-disable-next-line lint/noExplicitAny
         const {message, ...obj} = (value as any);
         category[key] = {
           ...obj,
@@ -788,6 +788,10 @@ export const descriptions = createMessages({
     MISSING_SPACE: {
       category: 'suppressions/missingSpace',
       message: 'Missing space between prefix and suppression categories',
+    },
+    NEXT_STATEMENT_NOT_FOUND: {
+      category: 'suppressions/missingTarget',
+      message: 'We could not find a statement to attach this suppression to',
     },
     PREFIX_TYPO: (prefix: string, suggestion: string) => ({
       category: 'suppressions/incorrectPrefix',

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -58,7 +58,7 @@ function addEmphasis(items: Array<string>): Array<string> {
   return items.map((item) => `<emphasis>${item}</emphasis>`);
 }
 
-// rome-disable-next-line lint/AEciilnnoptxy;
+// rome-ignore-next-line lint/AEciilnnoptxy;
 type InputMessagesFactory = (...params: Array<any>) => DiagnosticMetadataString;
 
 type InputMessagesCategory = {
@@ -102,11 +102,11 @@ type OutputMessages<Input extends InputMessages> = {
 function createMessages<Input extends InputMessages>(
   messages: Input,
 ): OutputMessages<Input> {
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   const out: OutputMessages<Input> = ({} as any);
 
   for (const categoryName in messages) {
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     const category: OutputMessagesCategory<any> = {};
     out[categoryName] = category;
 
@@ -119,7 +119,7 @@ function createMessages<Input extends InputMessages>(
           message: createBlessedDiagnosticMessage(value),
         };
       } else if (typeof value === 'function') {
-        // rome-disable-next-line lint/noExplicitAny
+        // rome-ignore-next-line lint/noExplicitAny
         const callback: InputMessagesFactory = (value as any);
 
         category[key] = function(...params) {
@@ -130,7 +130,7 @@ function createMessages<Input extends InputMessages>(
           };
         };
       } else {
-        // rome-disable-next-line lint/noExplicitAny
+        // rome-ignore-next-line lint/noExplicitAny
         const {message, ...obj} = (value as any);
         category[key] = {
           ...obj,

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -24,12 +24,15 @@ export type DiagnosticFilter = {
 
 export type DiagnosticFilters = Array<DiagnosticFilter>;
 
-export type DiagnosticSuppressionType = 'current' | 'next';
+export type DiagnosticSuppressionType = 'next' | 'current' | 'range';
 
 export type DiagnosticSuppression = {
   type: DiagnosticSuppressionType;
+  filename: string;
   category: string;
-  loc: SourceLocation;
+  startLine: Number1;
+  endLine: Number1;
+  commentLocation: SourceLocation;
 };
 
 export type DiagnosticSuppressions = Array<DiagnosticSuppression>;

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -24,7 +24,7 @@ export type DiagnosticFilter = {
 
 export type DiagnosticFilters = Array<DiagnosticFilter>;
 
-export type DiagnosticSuppressionType = 'next' | 'current' | 'range';
+export type DiagnosticSuppressionType = 'next' | 'current' | 'statement';
 
 export type DiagnosticSuppression = {
   type: DiagnosticSuppressionType;

--- a/packages/@romejs/events/Bridge.ts
+++ b/packages/@romejs/events/Bridge.ts
@@ -94,7 +94,7 @@ export default class Bridge {
   type: BridgeType;
 
   messageIdCounter: number;
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   events: Map<string, BridgeEvent<any, any>>;
 
   listeners: Set<string>;

--- a/packages/@romejs/events/Bridge.ts
+++ b/packages/@romejs/events/Bridge.ts
@@ -94,7 +94,7 @@ export default class Bridge {
   type: BridgeType;
 
   messageIdCounter: number;
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   events: Map<string, BridgeEvent<any, any>>;
 
   listeners: Set<string>;

--- a/packages/@romejs/events/BridgeEvent.ts
+++ b/packages/@romejs/events/BridgeEvent.ts
@@ -31,7 +31,7 @@ export type BridgeEventOptions = EventOptions & {
 };
 
 function validateDirection(
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   event: BridgeEvent<any, any>,
   invalidDirections: Array<[BridgeEventDirection, BridgeType]>,
   verb: string,

--- a/packages/@romejs/events/BridgeEvent.ts
+++ b/packages/@romejs/events/BridgeEvent.ts
@@ -31,7 +31,7 @@ export type BridgeEventOptions = EventOptions & {
 };
 
 function validateDirection(
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   event: BridgeEvent<any, any>,
   invalidDirections: Array<[BridgeEventDirection, BridgeType]>,
   verb: string,

--- a/packages/@romejs/events/index.ts
+++ b/packages/@romejs/events/index.ts
@@ -9,7 +9,7 @@ import Event from './Event';
 
 export {Event};
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export type AnyEvent = Event<any, any>;
 
 export {default as Bridge} from './Bridge';

--- a/packages/@romejs/events/index.ts
+++ b/packages/@romejs/events/index.ts
@@ -9,7 +9,7 @@ import Event from './Event';
 
 export {Event};
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export type AnyEvent = Event<any, any>;
 
 export {default as Bridge} from './Bridge';

--- a/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
+++ b/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
@@ -32,7 +32,7 @@ export default function getBindingIdentifiers(
     }
 
     for (const key of keys) {
-      // rome-suppress-next-line lint/noExplicitAny
+      // rome-disable-next-line lint/noExplicitAny
       const val = (node as any)[key];
       if (val === undefined) {
         continue;

--- a/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
+++ b/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
@@ -32,7 +32,7 @@ export default function getBindingIdentifiers(
     }
 
     for (const key of keys) {
-      // rome-disable-next-line lint/noExplicitAny
+      // rome-ignore-next-line lint/noExplicitAny
       const val = (node as any)[key];
       if (val === undefined) {
         continue;

--- a/packages/@romejs/js-ast-utils/removeLoc.ts
+++ b/packages/@romejs/js-ast-utils/removeLoc.ts
@@ -30,11 +30,11 @@ const removeLocTransform: TransformVisitors = [
         const newNode: JSNodeBase = removeProp(node);
 
         // Also remove any `undefined` properties
-        // rome-suppress-next-line lint/noExplicitAny
+        // rome-disable-next-line lint/noExplicitAny
         const escaped: any = newNode;
         for (const key in newNode) {
           if (escaped[key] === undefined) {
-            // rome-suppress-next-line lint/noDelete
+            // rome-disable-next-line lint/noDelete
             delete escaped[key];
           }
         }

--- a/packages/@romejs/js-ast-utils/removeLoc.ts
+++ b/packages/@romejs/js-ast-utils/removeLoc.ts
@@ -30,11 +30,11 @@ const removeLocTransform: TransformVisitors = [
         const newNode: JSNodeBase = removeProp(node);
 
         // Also remove any `undefined` properties
-        // rome-disable-next-line lint/noExplicitAny
+        // rome-ignore-next-line lint/noExplicitAny
         const escaped: any = newNode;
         for (const key in newNode) {
           if (escaped[key] === undefined) {
-            // rome-disable-next-line lint/noDelete
+            // rome-ignore-next-line lint/noDelete
             delete escaped[key];
           }
         }

--- a/packages/@romejs/js-ast-utils/template.ts
+++ b/packages/@romejs/js-ast-utils/template.ts
@@ -146,7 +146,7 @@ export default function template(
     const {type, path} = placeholderPaths[i];
 
     const substitute: AnyNode = createIdentifier(substitutions[i], type);
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     let target: any = newAst;
 
     for (let i = 0; i < path.length; i++) {

--- a/packages/@romejs/js-ast-utils/template.ts
+++ b/packages/@romejs/js-ast-utils/template.ts
@@ -146,7 +146,7 @@ export default function template(
     const {type, path} = placeholderPaths[i];
 
     const substitute: AnyNode = createIdentifier(substitutions[i], type);
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     let target: any = newAst;
 
     for (let i = 0; i < path.length; i++) {

--- a/packages/@romejs/js-compiler/api/createHook.ts
+++ b/packages/@romejs/js-compiler/api/createHook.ts
@@ -22,13 +22,13 @@ export type HookDescriptor<State, CallArg, CallReturn> = {
   exit?: (path: Path, state: State) => TransformExitResult;
 };
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export type AnyHookDescriptor = HookDescriptor<any, any, any>;
 
 export type HookInstance = {
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   state: any;
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   descriptor: HookDescriptor<any, any, any>;
 };
 

--- a/packages/@romejs/js-compiler/api/createHook.ts
+++ b/packages/@romejs/js-compiler/api/createHook.ts
@@ -22,13 +22,13 @@ export type HookDescriptor<State, CallArg, CallReturn> = {
   exit?: (path: Path, state: State) => TransformExitResult;
 };
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export type AnyHookDescriptor = HookDescriptor<any, any, any>;
 
 export type HookInstance = {
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   state: any;
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   descriptor: HookDescriptor<any, any, any>;
 };
 

--- a/packages/@romejs/js-compiler/lib/CompilerContext.ts
+++ b/packages/@romejs/js-compiler/lib/CompilerContext.ts
@@ -134,7 +134,10 @@ export default class CompilerContext {
 
     this.comments = new CommentsConsumer(ast.comments);
 
-    const {suppressions, diagnostics} = extractSuppressionsFromProgram(ast);
+    const {suppressions, diagnostics} = extractSuppressionsFromProgram(
+      this,
+      ast,
+    );
     this.suppressions = suppressions;
     this.diagnostics = new DiagnosticsProcessor();
     this.diagnostics.addDiagnostics(diagnostics);

--- a/packages/@romejs/js-compiler/lib/Path.ts
+++ b/packages/@romejs/js-compiler/lib/Path.ts
@@ -94,7 +94,7 @@ export default class Path {
   listKey: undefined | number;
 
   callHook<CallArg, CallReturn>(
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     descriptor: HookDescriptor<any, CallArg, CallReturn>,
     arg: CallArg,
     optionalRet?: CallReturn,
@@ -124,7 +124,7 @@ export default class Path {
   }
 
   provideHook<State>(
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     descriptor: HookDescriptor<State, any, any>,
     state?: State,
   ): AnyNode {
@@ -173,7 +173,7 @@ export default class Path {
   }
 
   getChildPath(key: string): Path {
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     const node = (this.node as any)[key];
     if (node === undefined) {
       throw new Error(
@@ -193,7 +193,7 @@ export default class Path {
   }
 
   getChildPaths(key: string): Array<Path> {
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     const nodes = (this.node as any)[key];
 
     if (nodes === undefined) {

--- a/packages/@romejs/js-compiler/lib/Path.ts
+++ b/packages/@romejs/js-compiler/lib/Path.ts
@@ -94,7 +94,7 @@ export default class Path {
   listKey: undefined | number;
 
   callHook<CallArg, CallReturn>(
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     descriptor: HookDescriptor<any, CallArg, CallReturn>,
     arg: CallArg,
     optionalRet?: CallReturn,
@@ -124,7 +124,7 @@ export default class Path {
   }
 
   provideHook<State>(
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     descriptor: HookDescriptor<State, any, any>,
     state?: State,
   ): AnyNode {
@@ -173,7 +173,7 @@ export default class Path {
   }
 
   getChildPath(key: string): Path {
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     const node = (this.node as any)[key];
     if (node === undefined) {
       throw new Error(
@@ -193,7 +193,7 @@ export default class Path {
   }
 
   getChildPaths(key: string): Array<Path> {
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     const nodes = (this.node as any)[key];
 
     if (nodes === undefined) {

--- a/packages/@romejs/js-compiler/methods/reduce.ts
+++ b/packages/@romejs/js-compiler/methods/reduce.ts
@@ -170,7 +170,7 @@ export default function reduce(
 
     // Reduce the children
     for (const key of visitorKeys) {
-      // rome-suppress-next-line lint/noExplicitAny
+      // rome-disable-next-line lint/noExplicitAny
       const oldVal = (node as any)[key];
 
       if (Array.isArray(oldVal)) {

--- a/packages/@romejs/js-compiler/methods/reduce.ts
+++ b/packages/@romejs/js-compiler/methods/reduce.ts
@@ -170,7 +170,7 @@ export default function reduce(
 
     // Reduce the children
     for (const key of visitorKeys) {
-      // rome-disable-next-line lint/noExplicitAny
+      // rome-ignore-next-line lint/noExplicitAny
       const oldVal = (node as any)[key];
 
       if (Array.isArray(oldVal)) {

--- a/packages/@romejs/js-compiler/scope/evaluators/index.ts
+++ b/packages/@romejs/js-compiler/scope/evaluators/index.ts
@@ -39,7 +39,7 @@ import {AnyNode} from '@romejs/js-ast';
 type ScopeEvaluator = {
   creator: boolean;
 
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   build: (node: any, parent: AnyNode, scope: Scope) => void | Scope;
 };
 

--- a/packages/@romejs/js-compiler/scope/evaluators/index.ts
+++ b/packages/@romejs/js-compiler/scope/evaluators/index.ts
@@ -39,7 +39,7 @@ import {AnyNode} from '@romejs/js-ast';
 type ScopeEvaluator = {
   creator: boolean;
 
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   build: (node: any, parent: AnyNode, scope: Scope) => void | Scope;
 };
 

--- a/packages/@romejs/js-compiler/suppressions.test.md
+++ b/packages/@romejs/js-compiler/suppressions.test.md
@@ -6,20 +6,35 @@
 
 ```javascript
 Object {
-  suppressions: Array []
   diagnostics: Array [
     Object {
       description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
+        category: 'suppressions/duplicate'
+        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Duplicate suppression category <emphasis>foo</emphasis>'}
       }
       location: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
+      }
+    }
+  ]
+  suppressions: Array [
+    Object {
+      category: 'foo'
+      endLine: 1
+      filename: 'unknown'
+      startLine: 1
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -41,20 +56,15 @@ Object {
 
 ```javascript
 Object {
-  suppressions: Array []
-  diagnostics: Array [
+  diagnostics: Array []
+  suppressions: Array [
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
-      }
-      location: Object {
+      category: 'foo'
+      endLine: 1
+      filename: 'unknown'
+      startLine: 1
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -69,17 +79,32 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
+      category: 'bar'
+      endLine: 1
+      filename: 'unknown'
+      startLine: 1
+      suppressionType: 'current'
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 1
+        }
       }
-      location: Object {
+    }
+    Object {
+      category: 'foo'
+      endLine: 2
+      filename: 'unknown'
+      startLine: 2
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -94,17 +119,32 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
+      category: 'bar'
+      endLine: 2
+      filename: 'unknown'
+      startLine: 2
+      suppressionType: 'current'
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 2
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 2
+        }
       }
-      location: Object {
+    }
+    Object {
+      category: 'foo'
+      endLine: 3
+      filename: 'unknown'
+      startLine: 3
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -119,17 +159,32 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
+      category: 'bar'
+      endLine: 3
+      filename: 'unknown'
+      startLine: 3
+      suppressionType: 'current'
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 3
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 3
+        }
       }
-      location: Object {
+    }
+    Object {
+      category: 'foo'
+      endLine: 4
+      filename: 'unknown'
+      startLine: 4
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -144,17 +199,52 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
+      category: 'bar'
+      endLine: 4
+      filename: 'unknown'
+      startLine: 4
+      suppressionType: 'current'
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 4
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 4
+        }
       }
-      location: Object {
+    }
+    Object {
+      category: 'cat'
+      endLine: 4
+      filename: 'unknown'
+      startLine: 4
+      suppressionType: 'current'
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 0
+          index: 0
+          line: 4
+        }
+        start: Object {
+          column: 0
+          index: 0
+          line: 4
+        }
+      }
+    }
+    Object {
+      category: 'dog'
+      endLine: 4
+      filename: 'unknown'
+      startLine: 4
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -176,20 +266,15 @@ Object {
 
 ```javascript
 Object {
-  suppressions: Array []
-  diagnostics: Array [
+  diagnostics: Array []
+  suppressions: Array [
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
-      }
-      location: Object {
+      category: 'foo'
+      endLine: 1
+      filename: 'unknown'
+      startLine: 1
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -204,17 +289,12 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
-      }
-      location: Object {
+      category: 'foo'
+      endLine: 2
+      filename: 'unknown'
+      startLine: 2
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -229,17 +309,12 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
-      }
-      location: Object {
+      category: 'foo'
+      endLine: 3
+      filename: 'unknown'
+      startLine: 3
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -254,17 +329,12 @@ Object {
       }
     }
     Object {
-      description: Object {
-        category: 'suppressions/incorrectPrefix'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Invalid suppression prefix <emphasis>rome-suppress</emphasis>'}
-        advice: Array [
-          log {
-            category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
-          }
-        ]
-      }
-      location: Object {
+      category: 'foo'
+      endLine: 4
+      filename: 'unknown'
+      startLine: 4
+      suppressionType: 'current'
+      commentLocation: Object {
         filename: 'unknown'
         end: Object {
           column: 0
@@ -295,7 +365,7 @@ Object {
         advice: Array [
           log {
             category: 'info'
-            text: 'Did you mean <emphasis>rome-suppress-next-line</emphasis>?'
+            text: 'Did you mean <emphasis>rome-disable-next-line</emphasis>?'
           }
         ]
       }

--- a/packages/@romejs/js-compiler/suppressions.test.md
+++ b/packages/@romejs/js-compiler/suppressions.test.md
@@ -365,7 +365,7 @@ Object {
         advice: Array [
           log {
             category: 'info'
-            text: 'Did you mean <emphasis>rome-disable-next-line</emphasis>?'
+            text: 'Did you mean <emphasis>rome-ignore-next-line</emphasis>?'
           }
         ]
       }

--- a/packages/@romejs/js-compiler/suppressions.test.ts
+++ b/packages/@romejs/js-compiler/suppressions.test.ts
@@ -44,10 +44,10 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-disable-line foo', 1),
-        generateComment('* rome-disable-line foo', 2),
-        generateComment(' * rome-disable-line foo', 3),
-        generateComment('* wow\n * rome-disable-line foo', 4),
+        generateComment('rome-ignore-line foo', 1),
+        generateComment('* rome-ignore-line foo', 2),
+        generateComment(' * rome-ignore-line foo', 3),
+        generateComment('* wow\n * rome-ignore-line foo', 4),
       ]),
     );
   },
@@ -58,11 +58,11 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-disable-line foo bar', 1),
-        generateComment('* rome-disable-line foo bar', 2),
-        generateComment(' * rome-disable-line foo bar', 3),
+        generateComment('rome-ignore-line foo bar', 1),
+        generateComment('* rome-ignore-line foo bar', 2),
+        generateComment(' * rome-ignore-line foo bar', 3),
         generateComment(
-          '* wow\n * rome-disable-line foo bar\n* rome-disable-line cat dog',
+          '* wow\n * rome-ignore-line foo bar\n* rome-ignore-line cat dog',
           4,
         ),
       ]),
@@ -86,7 +86,7 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-disable-line foo foo', 1),
+        generateComment('rome-ignore-line foo foo', 1),
       ]),
     );
   },

--- a/packages/@romejs/js-compiler/suppressions.test.ts
+++ b/packages/@romejs/js-compiler/suppressions.test.ts
@@ -6,9 +6,19 @@
  */
 
 import {test} from 'rome';
-import {extractSuppressionsFromComments} from './suppressions';
-import {CommentBlock} from '@romejs/js-ast';
+import {extractSuppressionsFromProgram} from './suppressions';
+import {AnyComment, CommentBlock, MOCK_PROGRAM, program} from '@romejs/js-ast';
 import {ob1Coerce1, ob1Number0} from '@romejs/ob1';
+import CompilerContext from './lib/CompilerContext';
+
+function extractSuppressionsFromComments(comments: Array<AnyComment>) {
+  const ast = program.create({
+    ...MOCK_PROGRAM,
+    comments,
+  });
+  const context = new CompilerContext({ast});
+  return extractSuppressionsFromProgram(context, ast);
+}
 
 function generateComment(value: string, line: number): CommentBlock {
   const pos = {
@@ -34,10 +44,10 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-suppress foo', 1),
-        generateComment('* rome-suppress foo', 2),
-        generateComment(' * rome-suppress foo', 3),
-        generateComment('* wow\n * rome-suppress foo', 4),
+        generateComment('rome-disable-line foo', 1),
+        generateComment('* rome-disable-line foo', 2),
+        generateComment(' * rome-disable-line foo', 3),
+        generateComment('* wow\n * rome-disable-line foo', 4),
       ]),
     );
   },
@@ -48,11 +58,11 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-suppress foo bar', 1),
-        generateComment('* rome-suppress foo bar', 2),
-        generateComment(' * rome-suppress foo bar', 3),
+        generateComment('rome-disable-line foo bar', 1),
+        generateComment('* rome-disable-line foo bar', 2),
+        generateComment(' * rome-disable-line foo bar', 3),
         generateComment(
-          '* wow\n * rome-suppress foo bar\n* rome-suppress cat dog',
+          '* wow\n * rome-disable-line foo bar\n* rome-disable-line cat dog',
           4,
         ),
       ]),
@@ -76,7 +86,7 @@ test(
   async (t) => {
     t.snapshot(
       extractSuppressionsFromComments([
-        generateComment('rome-suppress foo foo', 1),
+        generateComment('rome-disable-line foo foo', 1),
       ]),
     );
   },

--- a/packages/@romejs/js-compiler/suppressions.ts
+++ b/packages/@romejs/js-compiler/suppressions.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {AnyComment, Program} from '@romejs/js-ast';
+import {AnyComment, AnyNode, Program} from '@romejs/js-ast';
 import {
   DiagnosticLocation,
   DiagnosticSuppression,
@@ -15,30 +15,87 @@ import {
   descriptions,
 } from '@romejs/diagnostics';
 import {Dict} from '@romejs/typescript-helpers';
-import {ob1Add} from '@romejs/ob1';
+import {Number1, ob1Inc} from '@romejs/ob1';
+import CompilerContext from './lib/CompilerContext';
+import Path from './lib/Path';
 
-export const SUPPRESSION_NEXT_LINE_START = 'rome-suppress-next-line';
-const SUPPRESSION_CURRENT_LINE_START = 'rome-suppress-current-line';
+export const SUPPRESSION_NEXT_LINE_START = 'rome-disable-next-line';
+const SUPPRESSION_CURRENT_LINE_START = 'rome-disable-line';
+const SUPPRESSION_NEXT_STATEMENT_START = 'rome-disable-next-statement';
 
-const SUPPRESSION_PREFIX_MISTAKES: Dict<string> = {
-  'rome-suppress': SUPPRESSION_NEXT_LINE_START,
-  '@rome-suppress': SUPPRESSION_NEXT_LINE_START,
-  'rome-ignore': SUPPRESSION_NEXT_LINE_START,
-  '@rome-ignore': SUPPRESSION_NEXT_LINE_START,
-  '@rome-suppression-next-line': SUPPRESSION_NEXT_LINE_START,
-  '@rome-suppression-current-line': SUPPRESSION_CURRENT_LINE_START,
+const prefixMistakes: Dict<string> = {
+  disable: SUPPRESSION_NEXT_LINE_START,
+  suppress: SUPPRESSION_NEXT_LINE_START,
+  ignore: SUPPRESSION_NEXT_LINE_START,
+  'next-statement': SUPPRESSION_NEXT_STATEMENT_START,
+  'next-line': SUPPRESSION_NEXT_LINE_START,
+  line: SUPPRESSION_CURRENT_LINE_START,
+  'current-line': SUPPRESSION_CURRENT_LINE_START,
 };
+for (const key in prefixMistakes) {
+  const suggestion = prefixMistakes[key];
+  prefixMistakes[`ignore-${key}`] = suggestion;
+  prefixMistakes[`suppress-${key}`] = suggestion;
+  prefixMistakes[`disable-${key}`] = suggestion;
+}
 
 type ExtractedSuppressions = {
   suppressions: DiagnosticSuppressions;
   diagnostics: Diagnostics;
 };
 
-export function extractSuppressionsFromComment(
+type NodeToComment = Map<AnyComment, AnyNode>;
+
+// Perform a test on the comment line to see if it's a potential suppression typo
+function detectPossibleMistake(
+  line: string,
+):
+  | undefined
+  | {
+      prefix: string;
+      suggestion: string;
+    } {
+  // Match the first word
+  const prefixMatch = line.match(/^(?:[\s]+|)(.*?)[$\s]/);
+  if (prefixMatch == null) {
+    return undefined;
+  }
+
+  // Normalize the prefix, removing leading @
+  const prefix = prefixMatch[1];
+  let normalizedPrefix = prefix;
+  normalizedPrefix = normalizedPrefix.replace(/^@/, '');
+
+  // "Fast" check to ignore
+  if (!normalizedPrefix.startsWith('rome')) {
+    return undefined;
+  }
+
+  // Replace all underscores with dashes, remove leading rome and any dashes
+  normalizedPrefix = normalizedPrefix.replace(/_/g, '-');
+  normalizedPrefix = normalizedPrefix.replace(/^rome/, '');
+  normalizedPrefix = normalizedPrefix.replace(/^-+/, '');
+
+  for (const key in prefixMistakes) {
+    const suggestion = prefixMistakes[key];
+    if (normalizedPrefix.startsWith(key)) {
+      return {
+        suggestion,
+        prefix,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function extractSuppressionsFromComment(
+  context: CompilerContext,
   comment: AnyComment,
+  getNodeToComment: () => NodeToComment,
 ): undefined | ExtractedSuppressions {
-  const {loc} = comment;
-  if (loc === undefined) {
+  const commentLocation = comment.loc;
+  if (commentLocation === undefined) {
     return undefined;
   }
 
@@ -54,29 +111,55 @@ export function extractSuppressionsFromComment(
 
   for (const line of cleanLines) {
     // Find suppression start
-    let suppressionType: undefined | DiagnosticSuppressionType;
     let matchedPrefix: undefined | string;
+    let startLine: undefined | Number1;
+    let endLine: undefined | Number1;
+    let suppressionType: undefined | DiagnosticSuppressionType;
     if (line.startsWith(SUPPRESSION_CURRENT_LINE_START)) {
       matchedPrefix = SUPPRESSION_CURRENT_LINE_START;
+      startLine = commentLocation.start.line;
+      endLine = startLine;
       suppressionType = 'current';
     }
     if (line.startsWith(SUPPRESSION_NEXT_LINE_START)) {
       matchedPrefix = SUPPRESSION_NEXT_LINE_START;
+      startLine = ob1Inc(commentLocation.start.line);
+      endLine = startLine;
       suppressionType = 'next';
     }
+    if (line.startsWith(SUPPRESSION_NEXT_STATEMENT_START)) {
+      matchedPrefix = SUPPRESSION_NEXT_STATEMENT_START;
 
-    if (suppressionType === undefined || matchedPrefix === undefined) {
-      for (const prefix in SUPPRESSION_PREFIX_MISTAKES) {
-        const suggestion = SUPPRESSION_PREFIX_MISTAKES[prefix];
-        if (line.startsWith(prefix)) {
-          diagnostics.push({
-            description: descriptions.SUPPRESSIONS.PREFIX_TYPO(
-              prefix,
-              suggestion,
-            ),
-            location: loc,
-          });
-        }
+      const nodeToComment = getNodeToComment();
+      const nextNode = nodeToComment.get(comment);
+      if (nextNode === undefined || nextNode.loc === undefined) {
+        diagnostics.push({
+          description: descriptions.SUPPRESSIONS.NEXT_STATEMENT_NOT_FOUND,
+          location: commentLocation,
+        });
+        continue;
+      } else {
+        suppressionType = 'range';
+        startLine = nextNode.loc.start.line;
+        endLine = nextNode.loc.end.line;
+      }
+    }
+
+    if (
+      matchedPrefix === undefined ||
+      endLine === undefined ||
+      startLine === undefined ||
+      suppressionType === undefined
+    ) {
+      const mistake = detectPossibleMistake(line);
+      if (mistake !== undefined) {
+        diagnostics.push({
+          description: descriptions.SUPPRESSIONS.PREFIX_TYPO(
+            mistake.prefix,
+            mistake.suggestion,
+          ),
+          location: commentLocation,
+        });
       }
       continue;
     }
@@ -85,7 +168,7 @@ export function extractSuppressionsFromComment(
     if (lineWithoutPrefix[0] !== ' ') {
       diagnostics.push({
         description: descriptions.SUPPRESSIONS.MISSING_SPACE,
-        location: loc,
+        location: commentLocation,
       });
       continue;
     }
@@ -108,15 +191,18 @@ export function extractSuppressionsFromComment(
       if (suppressedCategories.has(category)) {
         diagnostics.push({
           description: descriptions.SUPPRESSIONS.DUPLICATE(category),
-          location: loc,
+          location: commentLocation,
         });
       } else {
         suppressedCategories.add(category);
 
         suppressions.push({
-          type: suppressionType,
+          suppressionType,
+          filename: context.filename,
           category,
-          loc,
+          commentLocation,
+          startLine,
+          endLine,
         });
       }
 
@@ -133,14 +219,56 @@ export function extractSuppressionsFromComment(
   }
 }
 
-export function extractSuppressionsFromComments(
-  comments: Array<AnyComment>,
+export function extractSuppressionsFromProgram(
+  context: CompilerContext,
+  ast: Program,
 ): ExtractedSuppressions {
+  const {comments} = ast;
+
   let diagnostics: Diagnostics = [];
   let suppressions: DiagnosticSuppressions = [];
 
+  let cachedNodeToComment: undefined | NodeToComment;
+
+  // Lazily instantiate NodeToComment only when it's needed
+  function getNodeToComment(): NodeToComment {
+    if (cachedNodeToComment !== undefined) {
+      return cachedNodeToComment;
+    }
+
+    const nodeToComment: NodeToComment = new Map();
+    cachedNodeToComment = nodeToComment;
+
+    context.reduce(
+      ast,
+      {
+        name: 'extractSuppressions',
+        enter(path: Path): AnyNode {
+          const {node} = path;
+
+          for (const comment of context.comments.getCommentsFromIds(
+            node.leadingComments,
+          )) {
+            nodeToComment.set(comment, node);
+          }
+
+          return node;
+        },
+      },
+      {
+        noScopeCreation: true,
+      },
+    );
+
+    return nodeToComment;
+  }
+
   for (const comment of comments) {
-    const result = extractSuppressionsFromComment(comment);
+    const result = extractSuppressionsFromComment(
+      context,
+      comment,
+      getNodeToComment,
+    );
     if (result !== undefined) {
       diagnostics = diagnostics.concat(result.diagnostics);
       suppressions = suppressions.concat(result.suppressions);
@@ -150,29 +278,15 @@ export function extractSuppressionsFromComments(
   return {suppressions, diagnostics};
 }
 
-export function extractSuppressionsFromProgram(
-  ast: Program,
-): ExtractedSuppressions {
-  return extractSuppressionsFromComments(ast.comments);
-}
-
 export function matchesSuppression(
-  loc: DiagnosticLocation,
+  {filename, start, end}: DiagnosticLocation,
   suppression: DiagnosticSuppression,
 ): boolean {
-  const targetLine =
-    suppression.type === 'current'
-      ? suppression.loc.end.line
-      : ob1Add(suppression.loc.end.line, 1);
-
-  if (
-    loc.filename !== undefined &&
-    loc.start !== undefined &&
-    loc.filename === suppression.loc.filename &&
-    loc.start.line === targetLine
-  ) {
-    return true;
-  }
-
-  return false;
+  return (
+    filename === suppression.filename &&
+    start !== undefined &&
+    end !== undefined &&
+    start.line >= suppression.startLine &&
+    end.line <= suppression.endLine
+  );
 }

--- a/packages/@romejs/js-compiler/suppressions.ts
+++ b/packages/@romejs/js-compiler/suppressions.ts
@@ -139,7 +139,7 @@ function extractSuppressionsFromComment(
         });
         continue;
       } else {
-        suppressionType = 'range';
+        suppressionType = 'statement';
         startLine = nextNode.loc.start.line;
         endLine = nextNode.loc.end.line;
       }

--- a/packages/@romejs/js-compiler/suppressions.ts
+++ b/packages/@romejs/js-compiler/suppressions.ts
@@ -197,7 +197,7 @@ function extractSuppressionsFromComment(
         suppressedCategories.add(category);
 
         suppressions.push({
-          suppressionType,
+          type: suppressionType,
           filename: context.filename,
           category,
           commentLocation,

--- a/packages/@romejs/js-compiler/suppressions.ts
+++ b/packages/@romejs/js-compiler/suppressions.ts
@@ -19,9 +19,9 @@ import {Number1, ob1Inc} from '@romejs/ob1';
 import CompilerContext from './lib/CompilerContext';
 import Path from './lib/Path';
 
-export const SUPPRESSION_NEXT_LINE_START = 'rome-disable-next-line';
-const SUPPRESSION_CURRENT_LINE_START = 'rome-disable-line';
-const SUPPRESSION_NEXT_STATEMENT_START = 'rome-disable-next-statement';
+export const SUPPRESSION_NEXT_LINE_START = 'rome-ignore-next-line';
+const SUPPRESSION_CURRENT_LINE_START = 'rome-ignore-line';
+const SUPPRESSION_NEXT_STATEMENT_START = 'rome-ignore-next-statement';
 
 const prefixMistakes: Dict<string> = {
   disable: SUPPRESSION_NEXT_LINE_START,

--- a/packages/@romejs/js-formatter/builders/index.ts
+++ b/packages/@romejs/js-formatter/builders/index.ts
@@ -7,7 +7,7 @@
 
 import {BuilderMethod} from '../Builder';
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 const builders: Map<string, BuilderMethod<any>> = new Map();
 
 export default builders;

--- a/packages/@romejs/js-formatter/builders/index.ts
+++ b/packages/@romejs/js-formatter/builders/index.ts
@@ -7,7 +7,7 @@
 
 import {BuilderMethod} from '../Builder';
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 const builders: Map<string, BuilderMethod<any>> = new Map();
 
 export default builders;

--- a/packages/@romejs/js-formatter/builders/objects/ObjectExpression.ts
+++ b/packages/@romejs/js-formatter/builders/objects/ObjectExpression.ts
@@ -51,7 +51,7 @@ export default function ObjectExpression(
     }
 
     tokens.push('...', builder.tokenize(node.rest, node));
-  } else {
+  } else if (props.length > 0) {
     // Add trailing comma
     tokens.push(ifBreak(','));
   }

--- a/packages/@romejs/js-formatter/node/parentheses.ts
+++ b/packages/@romejs/js-formatter/node/parentheses.ts
@@ -46,7 +46,7 @@ function isClassExtendsClause(node: AnyNode, parent: AnyNode): boolean {
 const parens: Map<
   AnyNode['type'],
   (
-    // rome-disable-next-line lint/noExplicitAny
+    // rome-ignore-next-line lint/noExplicitAny
     node: any,
     parent: AnyNode,
     printStack: Array<AnyNode>,

--- a/packages/@romejs/js-formatter/node/parentheses.ts
+++ b/packages/@romejs/js-formatter/node/parentheses.ts
@@ -46,7 +46,7 @@ function isClassExtendsClause(node: AnyNode, parent: AnyNode): boolean {
 const parens: Map<
   AnyNode['type'],
   (
-    // rome-suppress-next-line lint/noExplicitAny
+    // rome-disable-next-line lint/noExplicitAny
     node: any,
     parent: AnyNode,
     printStack: Array<AnyNode>,

--- a/packages/@romejs/js-formatter/test-fixtures/arrow/arrow-call/input.test.md
+++ b/packages/@romejs/js-formatter/test-fixtures/arrow/arrow-call/input.test.md
@@ -56,30 +56,51 @@ const testResults = results.testResults.map(testResult =>
 ### `Output`
 
 ```javascript
-const testResults = results.testResults.map((testResult) => formatResult(testResult, formatter, reporter));
+const testResults = results.testResults.map((testResult) =>
+  formatResult(testResult, formatter, reporter)
+);
 
 it(
   'mocks regexp instances',
   () => {
-    expect(() => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/))).not.toThrow();
+    expect(() =>
+      moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/))
+    ).not.toThrow();
   },
 );
 
-expect(() => asyncRequest({url: '/test-endpoint'})).toThrowError(/Required parameter/);
+expect(() => asyncRequest({url: '/test-endpoint'})).toThrowError(
+  /Required parameter/,
+);
 
-expect(() => asyncRequest({url: '/test-endpoint-but-with-a-long-url'})).toThrowError(/Required parameter/);
+expect(() => asyncRequest({url: '/test-endpoint-but-with-a-long-url'})).toThrowError(
+  /Required parameter/,
+);
 
-expect(() => asyncRequest({url: '/test-endpoint-but-with-a-suuuuuuuuper-long-url'})).toThrowError(/Required parameter/);
+expect(() =>
+  asyncRequest({url: '/test-endpoint-but-with-a-suuuuuuuuper-long-url'})
+).toThrowError(/Required parameter/);
 
 expect(() => asyncRequest({type: 'foo', url: '/test-endpoint'})).not.toThrowError();
 
-expect(() => asyncRequest({type: 'foo', url: '/test-endpoint-but-with-a-long-url'})).not.toThrowError();
+expect(() =>
+  asyncRequest({type: 'foo', url: '/test-endpoint-but-with-a-long-url'})
+).not.toThrowError();
 
-const a = Observable.fromPromise(axiosInstance.post('/carts/mine')).map((response) => response.data);
+const a = Observable.fromPromise(axiosInstance.post('/carts/mine')).map((
+  response,
+) => response.data);
 
-const b = Observable.fromPromise(axiosInstance.get(url)).map((response) => response.data);
+const b = Observable.fromPromise(axiosInstance.get(url)).map((response) =>
+  response.data
+);
 
-func(veryLoooooooooooooooooooooooongName, (veryLooooooooooooooooooooooooongName) => veryLoooooooooooooooongName.something());
+func(
+  veryLoooooooooooooooooooooooongName,
+  (veryLooooooooooooooooooooooooongName) =>
+    veryLoooooooooooooooongName.something()
+  ,
+);
 
 const composition = (ViewComponent, ContainerComponent) =>
   class extends React.Component {
@@ -87,6 +108,10 @@ const composition = (ViewComponent, ContainerComponent) =>
   }
 ;
 
-promise.then((result) => result.veryLongVariable.veryLongPropertyName > someOtherVariable ? 'ok' : 'fail');
+promise.then((result) =>
+  result.veryLongVariable.veryLongPropertyName > someOtherVariable
+    ? 'ok'
+    : 'fail'
+);
 
 ```

--- a/packages/@romejs/js-formatter/test-fixtures/arrow/nested/input.test.md
+++ b/packages/@romejs/js-formatter/test-fixtures/arrow/nested/input.test.md
@@ -39,7 +39,17 @@ runtimeAgent.getProperties(
 ### `Output`
 
 ```javascript
-Seq(typeDef.interface.groups).forEach((group) => Seq(group.members).forEach((member, memberName) => markdownDoc(member.doc, {typePath: typePath.concat(memberName.slice(1)), signatures: member.signatures})));
+Seq(typeDef.interface.groups).forEach((group) =>
+  Seq(group.members).forEach((member, memberName) =>
+    markdownDoc(
+      member.doc,
+      {
+        typePath: typePath.concat(memberName.slice(1)),
+        signatures: member.signatures,
+      },
+    )
+  )
+);
 
 const promiseFromCallback = (fn) =>
   new Promise((resolve, reject) =>

--- a/packages/@romejs/js-formatter/test-fixtures/arrow/params/input.test.md
+++ b/packages/@romejs/js-formatter/test-fixtures/arrow/params/input.test.md
@@ -333,7 +333,9 @@ foo(
 ### `Output`
 
 ```javascript
-fooooooooooooooooooooooooooooooooooooooooooooooooooo((action) => (next) => dispatch(action));
+fooooooooooooooooooooooooooooooooooooooooooooooooooo((action) => (next) =>
+  dispatch(action)
+);
 
 foo((
   {

--- a/packages/@romejs/js-parser/parser.ts
+++ b/packages/@romejs/js-parser/parser.ts
@@ -94,7 +94,7 @@ const SCOPE_TYPES: Array<ScopeType> = [
 ];
 
 const createJSParser = createParser((ParserCore, ParserWithRequiredPath) => {
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   class JSParser extends ParserWithRequiredPath<any, State> {
     constructor(options: JSParserOptions) {
       const state = createInitialState();

--- a/packages/@romejs/js-parser/parser.ts
+++ b/packages/@romejs/js-parser/parser.ts
@@ -94,7 +94,7 @@ const SCOPE_TYPES: Array<ScopeType> = [
 ];
 
 const createJSParser = createParser((ParserCore, ParserWithRequiredPath) => {
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   class JSParser extends ParserWithRequiredPath<any, State> {
     constructor(options: JSParserOptions) {
       const state = createInitialState();

--- a/packages/@romejs/node/index.ts
+++ b/packages/@romejs/node/index.ts
@@ -9,7 +9,7 @@ import mod = require('module');
 
 import {AbsoluteFilePath, AbsoluteFilePathMap, CWD_PATH} from '@romejs/path';
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 type RequireFunction = (name: string) => any;
 
 const requires: AbsoluteFilePathMap<RequireFunction> = new AbsoluteFilePathMap();
@@ -28,7 +28,7 @@ function getRequire(folder: AbsoluteFilePath = CWD_PATH): RequireFunction {
   return req;
 }
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export function requireGlobal(name: string, folder?: AbsoluteFilePath): any {
   return getRequire(folder)(name);
 }

--- a/packages/@romejs/node/index.ts
+++ b/packages/@romejs/node/index.ts
@@ -9,7 +9,7 @@ import mod = require('module');
 
 import {AbsoluteFilePath, AbsoluteFilePathMap, CWD_PATH} from '@romejs/path';
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 type RequireFunction = (name: string) => any;
 
 const requires: AbsoluteFilePathMap<RequireFunction> = new AbsoluteFilePathMap();
@@ -28,7 +28,7 @@ function getRequire(folder: AbsoluteFilePath = CWD_PATH): RequireFunction {
   return req;
 }
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export function requireGlobal(name: string, folder?: AbsoluteFilePath): any {
   return getRequire(folder)(name);
 }

--- a/packages/@romejs/pretty-format/index.ts
+++ b/packages/@romejs/pretty-format/index.ts
@@ -175,7 +175,7 @@ function formatFunction(val: Function, opts: FormatOptions): string {
     return label;
   }
 
-  // rome-suppress-next-line lint/noExplicitAny
+  // rome-disable-next-line lint/noExplicitAny
   return formatObject(label, (val as any), opts, []);
 }
 

--- a/packages/@romejs/pretty-format/index.ts
+++ b/packages/@romejs/pretty-format/index.ts
@@ -175,7 +175,7 @@ function formatFunction(val: Function, opts: FormatOptions): string {
     return label;
   }
 
-  // rome-disable-next-line lint/noExplicitAny
+  // rome-ignore-next-line lint/noExplicitAny
   return formatObject(label, (val as any), opts, []);
 }
 

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -93,7 +93,7 @@ export type ProjectConfigJSON = ProjectConfigJSONObjectReducer<ProjectConfigBase
 };
 
 // Weird way to get the value type from a map
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 type MapValue<T extends Map<string, any>> = NonNullable<ReturnType<T['get']>>;
 
 // Turn any file paths into strings
@@ -104,9 +104,9 @@ type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
   : Type extends Array<AbsoluteFilePath>
     ? Array<string>
     : Type extends AbsoluteFilePathSet
-      ? Array<string> // rome-disable-next-line lint/noExplicitAny
+      ? Array<string> // rome-ignore-next-line lint/noExplicitAny
       : Type extends Map<string, any>
-        ? Dict<MapValue<Type>> // rome-disable-next-line lint/noExplicitAny
+        ? Dict<MapValue<Type>> // rome-ignore-next-line lint/noExplicitAny
         : Type extends Dict<any>
           ? ProjectConfigJSONObjectReducer<Type>
           : Type;
@@ -131,7 +131,7 @@ export type PartialProjectConfig = Partial<ProjectConfigBase> & {
   >
 };
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 type PartialProjectValue<Type> = Type extends Map<string, any>
   ? Type
   : Partial<Type>;

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -93,7 +93,7 @@ export type ProjectConfigJSON = ProjectConfigJSONObjectReducer<ProjectConfigBase
 };
 
 // Weird way to get the value type from a map
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 type MapValue<T extends Map<string, any>> = NonNullable<ReturnType<T['get']>>;
 
 // Turn any file paths into strings
@@ -104,9 +104,9 @@ type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
   : Type extends Array<AbsoluteFilePath>
     ? Array<string>
     : Type extends AbsoluteFilePathSet
-      ? Array<string> // rome-suppress-next-line lint/noExplicitAny
+      ? Array<string> // rome-disable-next-line lint/noExplicitAny
       : Type extends Map<string, any>
-        ? Dict<MapValue<Type>> // rome-suppress-next-line lint/noExplicitAny
+        ? Dict<MapValue<Type>> // rome-disable-next-line lint/noExplicitAny
         : Type extends Dict<any>
           ? ProjectConfigJSONObjectReducer<Type>
           : Type;
@@ -131,7 +131,7 @@ export type PartialProjectConfig = Partial<ProjectConfigBase> & {
   >
 };
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 type PartialProjectValue<Type> = Type extends Map<string, any>
   ? Type
   : Partial<Type>;

--- a/packages/@romejs/typescript-helpers/index.ts
+++ b/packages/@romejs/typescript-helpers/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// rome-disable-next-line lint/noExplicitAny
+// rome-ignore-next-line lint/noExplicitAny
 export type Class<T, Args extends Array<unknown> = Array<any>> = {
   new (
     ...args: Args

--- a/packages/@romejs/typescript-helpers/index.ts
+++ b/packages/@romejs/typescript-helpers/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// rome-suppress-next-line lint/noExplicitAny
+// rome-disable-next-line lint/noExplicitAny
 export type Class<T, Args extends Array<unknown> = Array<any>> = {
   new (
     ...args: Args

--- a/scripts/vendor/rome.cjs
+++ b/scripts/vendor/rome.cjs
@@ -52121,7 +52121,7 @@ function ___R$project$rome$$romejs$js$generator$index_ts$generateJS(
 
   // project-rome/@romejs/js-compiler/suppressions.ts
 const ___R$$priv$project$rome$$romejs$js$compiler$suppressions_ts$SUPPRESSION_START = 'rome-suppress-next-line';
-  const ___R$$priv$project$rome$$romejs$js$compiler$suppressions_ts$PREFIX_MISTAKES = ['@rome-suppress', 'rome-ignore', '@rome-ignore'];
+  const ___R$$priv$project$rome$$romejs$js$compiler$suppressions_ts$PREFIX_MISTAKES = [];
 
   function ___R$$priv$project$rome$$romejs$js$compiler$suppressions_ts$extractSuppressionsFromComment(
     comment,


### PR DESCRIPTION
This PR renames the suppression comment prefixes. `suppress` is an awkward word to type. I was originally going to go with `disable` since that's what eslint uses but it doesn't make a lot of sense in the context of Rome. You're never disabling anything, you're just ignoring the error. The difference may not be significant but Rome can produce many diagnostics, from many different places.

- `rome-suppress-next-line` ->  `rome-ignore-next-line`
- `rome-suppress-current-line` -> `rome-ignore-line`

The previous typo checking is also still implemented. So if you use the old version, or any of the derivatives that we check for, then you'll receive a helpful error.

This PR also implements `rome-ignore-next-statement` that takes the range of the node it's attached to and suppresses everything within it. I'm not 100% sure how I feel about this. It feels very easily abused, or could even accidentally hide new errors unintentionally. We should have a good story if it's actually worth it. If the goal is to make it easier on the developer in the event of formatting causing newlines, then we should invest in some logic to automatically move or add suppressions rather than offering this capability.

Regardless, this was a worthwhile refactor.

Ref #371 cc @ooflorent 