### PR TITLE
One ignore comment to unite them all

### DIFF
--- a/packages/@romejs-integration/vscode/src/extension.ts
+++ b/packages/@romejs-integration/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient';
-// rome-ignore-next-line resolver/notFound
+// rome-ignore resolver/notFound
 import * as vscode from 'vscode';
 import path = require('path');
 

--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -46,7 +46,7 @@ type ListOptions = {
   start?: number;
 };
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 type WrapperFactory = <T extends (...args: Array<any>) => any>(callback: T) => T;
 
 export type ReporterOptions = {

--- a/packages/@romejs/codec-js-manifest/convert.ts
+++ b/packages/@romejs/codec-js-manifest/convert.ts
@@ -32,7 +32,7 @@ export function convertManifestToJSON(manifest: Manifest): JSONManifest {
     main: manifest.main,
     // TODO we now support fallbacks which means manifest.exports is lossy
     //exports: exportsToObject(manifest.exports),
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     exports: (manifest.raw.exports as any),
     author: manifest.author,
     contributors: manifest.contributors,

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -878,7 +878,7 @@ export default class Consumer {
       this.unexpected(
         descriptions.CONSUME.INVALID_STRING_SET_VALUE(
           value,
-          // rome-ignore-next-line lint/noExplicitAny
+          // rome-ignore lint/noExplicitAny
           ((validValues as any) as Array<string>),
         ),
         {
@@ -1201,7 +1201,7 @@ export default class Consumer {
     return this.value;
   }
 
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   asAny(): any {
     return this.value;
   }

--- a/packages/@romejs/core/client/ClientRequest.ts
+++ b/packages/@romejs/core/client/ClientRequest.ts
@@ -71,7 +71,7 @@ export default class ClientRequest {
   }
 
   async initFromLocal(
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     localCommand: LocalCommand<any>,
   ): Promise<MasterQueryResponse> {
     const {query} = this;

--- a/packages/@romejs/core/client/commands.ts
+++ b/packages/@romejs/core/client/commands.ts
@@ -33,7 +33,7 @@ export function createLocalCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export const localCommands: Map<string, LocalCommand<any>> = new Map();
 localCommands.set('init', init);
 localCommands.set('start', start);

--- a/packages/@romejs/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/WorkerBridge.ts
@@ -264,7 +264,7 @@ export default class WorkerBridge extends Bridge {
         hydrate(err, data) {
           return new DiagnosticsError(
             String(err.message),
-            // rome-ignore-next-line lint/noExplicitAny
+            // rome-ignore lint/noExplicitAny
             (data.diagnostics as any),
           );
         },

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -301,10 +301,9 @@ export default class Master {
     process.exit();
   }
 
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   wrapFatal<T extends (...args: Array<any>) => any>(callback: T): T {
-    return ((// rome-ignore-next-line lint/noExplicitAny
-    (...args: Array<any>): any => {
+    return (((...args: Array<any>): any => {
       try {
         const res = callback(...args);
         if (res instanceof Promise) {

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -344,7 +344,7 @@ export default class Bundler {
     }
 
     // TODO `{type: "module"}` will always fail since we've produced CJS bundles
-    // rome-ignore-next-line lint/noDelete
+    // rome-ignore lint/noDelete
     delete newManifest.type;
 
     return newManifest;

--- a/packages/@romejs/core/master/commands.ts
+++ b/packages/@romejs/core/master/commands.ts
@@ -49,7 +49,7 @@ export function createMasterCommand<Flags extends Dict<unknown>>(
   return cmd;
 }
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export const masterCommands: Map<string, MasterCommand<any>> = new Map();
 masterCommands.set('test', test);
 masterCommands.set('lint', lint);

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -322,9 +322,9 @@ async function createWatchmanWatcher(
         return;
       }
 
-      // rome-ignore-next-line lint/noExplicitAny
+      // rome-ignore lint/noExplicitAny
       const dirs: Array<[AbsoluteFilePath, any]> = [];
-      // rome-ignore-next-line lint/noExplicitAny
+      // rome-ignore lint/noExplicitAny
       const files: Array<[AbsoluteFilePath, any]> = [];
 
       for (const file of data.files) {
@@ -847,7 +847,7 @@ export default class MemoryFileSystem {
 
       const manifest = this.getManifest(packagePath);
 
-      // rome-ignore-next-line lint/camelCase
+      // rome-ignore lint/camelCase
       if ((manifest?.raw)?.haste_commonjs === true) {
         return false;
       }

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -783,16 +783,11 @@ export const descriptions = createMessages({
   },
   SUPPRESSIONS: {
     UNUSED: (suppression: DiagnosticSuppression) => {
-      let description = {
-        next: 'next line',
-        current: 'current line',
-        statement: 'next statement',
-      }[suppression.type];
-
+      let description = '';
       if (suppression.startLine === suppression.endLine) {
-        description += ` line ${suppression.startLine}`;
+        description = `line ${suppression.startLine}`;
       } else {
-        description += ` lines ${suppression.startLine}-${suppression.endLine}`;
+        description += `lines ${suppression.startLine} to ${suppression.endLine}`;
       }
 
       return {
@@ -802,7 +797,7 @@ export const descriptions = createMessages({
           {
             type: 'log',
             category: 'info',
-            text: `This suppression prefixes hides the <emphasis>${description}</emphasis>`,
+            text: `This suppression should hide <emphasis>${description}</emphasis>`,
           },
         ],
       };

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -59,7 +59,7 @@ function addEmphasis(items: Array<string>): Array<string> {
   return items.map((item) => `<emphasis>${item}</emphasis>`);
 }
 
-// rome-ignore-next-line lint/AEciilnnoptxy;
+// rome-ignore lint/AEciilnnoptxy;
 type InputMessagesFactory = (...params: Array<any>) => DiagnosticMetadataString;
 
 type InputMessagesCategory = {
@@ -103,11 +103,11 @@ type OutputMessages<Input extends InputMessages> = {
 function createMessages<Input extends InputMessages>(
   messages: Input,
 ): OutputMessages<Input> {
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   const out: OutputMessages<Input> = ({} as any);
 
   for (const categoryName in messages) {
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     const category: OutputMessagesCategory<any> = {};
     out[categoryName] = category;
 
@@ -120,7 +120,7 @@ function createMessages<Input extends InputMessages>(
           message: createBlessedDiagnosticMessage(value),
         };
       } else if (typeof value === 'function') {
-        // rome-ignore-next-line lint/noExplicitAny
+        // rome-ignore lint/noExplicitAny
         const callback: InputMessagesFactory = (value as any);
 
         category[key] = function(...params) {
@@ -131,7 +131,7 @@ function createMessages<Input extends InputMessages>(
           };
         };
       } else {
-        // rome-ignore-next-line lint/noExplicitAny
+        // rome-ignore lint/noExplicitAny
         const {message, ...obj} = (value as any);
         category[key] = {
           ...obj,
@@ -806,21 +806,10 @@ export const descriptions = createMessages({
       category: 'suppressions/missingSpace',
       message: 'Missing space between prefix and suppression categories',
     },
-    NEXT_STATEMENT_NOT_FOUND: {
+    MISSING_TARGET: {
       category: 'suppressions/missingTarget',
-      message: 'We could not find a statement to attach this suppression to',
+      message: 'We could not find a target for this suppression',
     },
-    PREFIX_TYPO: (prefix: string, suggestion: string) => ({
-      category: 'suppressions/incorrectPrefix',
-      message: markup`Invalid suppression prefix <emphasis>${prefix}</emphasis>`,
-      advice: [
-        {
-          type: 'log',
-          category: 'info',
-          text: `Did you mean <emphasis>${suggestion}</emphasis>?`,
-        },
-      ],
-    }),
     DUPLICATE: (category: string) => ({
       category: 'suppressions/duplicate',
       message: markup`Duplicate suppression category <emphasis>${category}</emphasis>`,

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -24,10 +24,7 @@ export type DiagnosticFilter = {
 
 export type DiagnosticFilters = Array<DiagnosticFilter>;
 
-export type DiagnosticSuppressionType = 'next' | 'current' | 'statement';
-
 export type DiagnosticSuppression = {
-  type: DiagnosticSuppressionType;
   filename: string;
   category: string;
   startLine: Number1;

--- a/packages/@romejs/events/Bridge.ts
+++ b/packages/@romejs/events/Bridge.ts
@@ -94,7 +94,7 @@ export default class Bridge {
   type: BridgeType;
 
   messageIdCounter: number;
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   events: Map<string, BridgeEvent<any, any>>;
 
   listeners: Set<string>;

--- a/packages/@romejs/events/BridgeEvent.ts
+++ b/packages/@romejs/events/BridgeEvent.ts
@@ -31,7 +31,7 @@ export type BridgeEventOptions = EventOptions & {
 };
 
 function validateDirection(
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   event: BridgeEvent<any, any>,
   invalidDirections: Array<[BridgeEventDirection, BridgeType]>,
   verb: string,

--- a/packages/@romejs/events/index.ts
+++ b/packages/@romejs/events/index.ts
@@ -9,7 +9,7 @@ import Event from './Event';
 
 export {Event};
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export type AnyEvent = Event<any, any>;
 
 export {default as Bridge} from './Bridge';

--- a/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
+++ b/packages/@romejs/js-ast-utils/getBindingIdentifiers.ts
@@ -32,7 +32,7 @@ export default function getBindingIdentifiers(
     }
 
     for (const key of keys) {
-      // rome-ignore-next-line lint/noExplicitAny
+      // rome-ignore lint/noExplicitAny
       const val = (node as any)[key];
       if (val === undefined) {
         continue;

--- a/packages/@romejs/js-ast-utils/removeLoc.ts
+++ b/packages/@romejs/js-ast-utils/removeLoc.ts
@@ -30,11 +30,11 @@ const removeLocTransform: TransformVisitors = [
         const newNode: JSNodeBase = removeProp(node);
 
         // Also remove any `undefined` properties
-        // rome-ignore-next-line lint/noExplicitAny
+        // rome-ignore lint/noExplicitAny
         const escaped: any = newNode;
         for (const key in newNode) {
           if (escaped[key] === undefined) {
-            // rome-ignore-next-line lint/noDelete
+            // rome-ignore lint/noDelete
             delete escaped[key];
           }
         }

--- a/packages/@romejs/js-ast-utils/template.ts
+++ b/packages/@romejs/js-ast-utils/template.ts
@@ -146,7 +146,7 @@ export default function template(
     const {type, path} = placeholderPaths[i];
 
     const substitute: AnyNode = createIdentifier(substitutions[i], type);
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     let target: any = newAst;
 
     for (let i = 0; i < path.length; i++) {

--- a/packages/@romejs/js-compiler/api/createHook.ts
+++ b/packages/@romejs/js-compiler/api/createHook.ts
@@ -22,13 +22,13 @@ export type HookDescriptor<State, CallArg, CallReturn> = {
   exit?: (path: Path, state: State) => TransformExitResult;
 };
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export type AnyHookDescriptor = HookDescriptor<any, any, any>;
 
 export type HookInstance = {
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   state: any;
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   descriptor: HookDescriptor<any, any, any>;
 };
 

--- a/packages/@romejs/js-compiler/lib/CompilerContext.ts
+++ b/packages/@romejs/js-compiler/lib/CompilerContext.ts
@@ -62,6 +62,7 @@ import {
 
 export type ContextArg = {
   ast: Program;
+  suppressions?: DiagnosticSuppressions;
   ref?: FileReference;
   sourceText?: string;
   project?: TransformProjectDefinition;
@@ -114,6 +115,7 @@ export default class CompilerContext {
         folder: undefined,
         config: DEFAULT_PROJECT_CONFIG,
       },
+      suppressions,
     } = arg;
 
     this.records = [];
@@ -133,14 +135,18 @@ export default class CompilerContext {
     this.rootScope = new RootScope(this, ast);
 
     this.comments = new CommentsConsumer(ast.comments);
-
-    const {suppressions, diagnostics} = extractSuppressionsFromProgram(
-      this,
-      ast,
-    );
-    this.suppressions = suppressions;
     this.diagnostics = new DiagnosticsProcessor();
-    this.diagnostics.addDiagnostics(diagnostics);
+
+    if (suppressions === undefined) {
+      const {suppressions, diagnostics} = extractSuppressionsFromProgram(
+        this,
+        ast,
+      );
+      this.suppressions = suppressions;
+      this.diagnostics.addDiagnostics(diagnostics);
+    } else {
+      this.suppressions = suppressions;
+    }
   }
 
   displayFilename: string;

--- a/packages/@romejs/js-compiler/lib/Path.ts
+++ b/packages/@romejs/js-compiler/lib/Path.ts
@@ -94,7 +94,7 @@ export default class Path {
   listKey: undefined | number;
 
   callHook<CallArg, CallReturn>(
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     descriptor: HookDescriptor<any, CallArg, CallReturn>,
     arg: CallArg,
     optionalRet?: CallReturn,
@@ -124,7 +124,7 @@ export default class Path {
   }
 
   provideHook<State>(
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     descriptor: HookDescriptor<State, any, any>,
     state?: State,
   ): AnyNode {
@@ -173,7 +173,7 @@ export default class Path {
   }
 
   getChildPath(key: string): Path {
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     const node = (this.node as any)[key];
     if (node === undefined) {
       throw new Error(
@@ -193,7 +193,7 @@ export default class Path {
   }
 
   getChildPaths(key: string): Array<Path> {
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     const nodes = (this.node as any)[key];
 
     if (nodes === undefined) {

--- a/packages/@romejs/js-compiler/lint/suppressions.ts
+++ b/packages/@romejs/js-compiler/lint/suppressions.ts
@@ -9,7 +9,7 @@ import {AnyComment, AnyNode, Program} from '@romejs/js-ast';
 import {CompilerContext} from '@romejs/js-compiler';
 import {Number1, ob1Get1} from '@romejs/ob1';
 import Path from '../lib/Path';
-import {SUPPRESSION_NEXT_LINE_START} from '../suppressions';
+import {SUPPRESSION_START} from '../suppressions';
 import {commentInjector} from '../transforms/defaultHooks/index';
 import {LintCompilerOptionsDecision} from '../types';
 
@@ -23,7 +23,7 @@ function getStartLine(node: AnyNode): undefined | Number1 {
 }
 
 function buildSuppressionCommentValue(categories: Set<string>): string {
-  return `${SUPPRESSION_NEXT_LINE_START} ${Array.from(categories).join(' ')}`;
+  return `${SUPPRESSION_START} ${Array.from(categories).join(' ')}`;
 }
 
 export function addSuppressions(context: CompilerContext, ast: Program): Program {
@@ -56,7 +56,7 @@ export function addSuppressions(context: CompilerContext, ast: Program): Program
     ).pop();
     if (
       lastComment !== undefined &&
-      lastComment.value.includes(SUPPRESSION_NEXT_LINE_START)
+      lastComment.value.includes(SUPPRESSION_START)
     ) {
       updateComment = lastComment;
     }
@@ -91,7 +91,7 @@ export function addSuppressions(context: CompilerContext, ast: Program): Program
         {
           ...updateComment,
           value: updateComment.value.replace(
-            SUPPRESSION_NEXT_LINE_START,
+            SUPPRESSION_START,
             buildSuppressionCommentValue(suppressionCategories),
           ),
         },

--- a/packages/@romejs/js-compiler/methods/reduce.ts
+++ b/packages/@romejs/js-compiler/methods/reduce.ts
@@ -170,7 +170,7 @@ export default function reduce(
 
     // Reduce the children
     for (const key of visitorKeys) {
-      // rome-ignore-next-line lint/noExplicitAny
+      // rome-ignore lint/noExplicitAny
       const oldVal = (node as any)[key];
 
       if (Array.isArray(oldVal)) {

--- a/packages/@romejs/js-compiler/methods/transform.ts
+++ b/packages/@romejs/js-compiler/methods/transform.ts
@@ -44,6 +44,7 @@ export default async function transform(
 
   let prevStageDiagnostics: Diagnostics = [];
   let prevStageCacheDeps: Array<string> = [];
+  let suppressions: undefined | DiagnosticSuppressions;
 
   // Run the previous stage
   if (stageNo > 0) {
@@ -51,9 +52,11 @@ export default async function transform(
     prevStageDiagnostics = prevStage.diagnostics;
     prevStageCacheDeps = prevStage.cacheDependencies;
     ast = prevStage.ast;
+    suppressions = prevStage.suppressions;
   }
 
   const context = new CompilerContext({
+    suppressions,
     ref: req.ref,
     sourceText: req.sourceText,
     ast,

--- a/packages/@romejs/js-compiler/scope/evaluators/index.ts
+++ b/packages/@romejs/js-compiler/scope/evaluators/index.ts
@@ -39,7 +39,7 @@ import {AnyNode} from '@romejs/js-ast';
 type ScopeEvaluator = {
   creator: boolean;
 
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   build: (node: any, parent: AnyNode, scope: Scope) => void | Scope;
 };
 

--- a/packages/@romejs/js-compiler/suppressions.test.md
+++ b/packages/@romejs/js-compiler/suppressions.test.md
@@ -10,13 +10,13 @@ Object {
     Object {
       description: Object {
         category: 'suppressions/duplicate'
-        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Duplicate suppression category <emphasis>foo</emphasis>'}
+        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Duplicate suppression category <emphasis>dog</emphasis>'}
       }
       location: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
+          column: 22
+          index: 22
           line: 1
         }
         start: Object {
@@ -26,25 +26,81 @@ Object {
         }
       }
     }
+    Object {
+      description: Object {
+        category: 'suppressions/duplicate'
+        message: PARTIAL_BLESSED_DIAGNOSTIC_MESSAGE {value: 'Duplicate suppression category <emphasis>dog</emphasis>'}
+      }
+      location: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 26
+          index: 57
+          line: 4
+        }
+        start: Object {
+          column: 0
+          index: 31
+          line: 4
+        }
+      }
+    }
   ]
   suppressions: Array [
     Object {
-      category: 'foo'
-      endLine: 1
+      category: 'dog'
+      endLine: 2
       filename: 'unknown'
-      startLine: 1
-      suppressionType: 'current'
+      startLine: 2
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
+          column: 22
+          index: 22
           line: 1
         }
         start: Object {
           column: 0
           index: 0
           line: 1
+        }
+      }
+    }
+    Object {
+      category: 'dog'
+      endLine: 5
+      filename: 'unknown'
+      startLine: 5
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 26
+          index: 57
+          line: 4
+        }
+        start: Object {
+          column: 0
+          index: 31
+          line: 4
+        }
+      }
+    }
+    Object {
+      category: 'cat'
+      endLine: 5
+      filename: 'unknown'
+      startLine: 5
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 26
+          index: 57
+          line: 4
+        }
+        start: Object {
+          column: 0
+          index: 31
+          line: 4
         }
       }
     }
@@ -60,201 +116,153 @@ Object {
   suppressions: Array [
     Object {
       category: 'foo'
-      endLine: 1
-      filename: 'unknown'
-      startLine: 1
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-        start: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-      }
-    }
-    Object {
-      category: 'bar'
-      endLine: 1
-      filename: 'unknown'
-      startLine: 1
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-        start: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-      }
-    }
-    Object {
-      category: 'foo'
       endLine: 2
       filename: 'unknown'
       startLine: 2
-      suppressionType: 'current'
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 2
+          column: 22
+          index: 22
+          line: 1
         }
         start: Object {
           column: 0
           index: 0
-          line: 2
+          line: 1
         }
       }
     }
     Object {
-      category: 'bar'
+      category: 'dog'
       endLine: 2
       filename: 'unknown'
       startLine: 2
-      suppressionType: 'current'
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 2
+          column: 22
+          index: 22
+          line: 1
         }
         start: Object {
           column: 0
           index: 0
-          line: 2
-        }
-      }
-    }
-    Object {
-      category: 'foo'
-      endLine: 3
-      filename: 'unknown'
-      startLine: 3
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
-          line: 3
-        }
-        start: Object {
-          column: 0
-          index: 0
-          line: 3
+          line: 1
         }
       }
     }
     Object {
       category: 'bar'
-      endLine: 3
+      endLine: 5
       filename: 'unknown'
-      startLine: 3
-      suppressionType: 'current'
+      startLine: 5
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 3
-        }
-        start: Object {
-          column: 0
-          index: 0
-          line: 3
-        }
-      }
-    }
-    Object {
-      category: 'foo'
-      endLine: 4
-      filename: 'unknown'
-      startLine: 4
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
+          column: 26
+          index: 57
           line: 4
         }
         start: Object {
           column: 0
-          index: 0
-          line: 4
-        }
-      }
-    }
-    Object {
-      category: 'bar'
-      endLine: 4
-      filename: 'unknown'
-      startLine: 4
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
-          line: 4
-        }
-        start: Object {
-          column: 0
-          index: 0
+          index: 31
           line: 4
         }
       }
     }
     Object {
       category: 'cat'
-      endLine: 4
+      endLine: 5
       filename: 'unknown'
-      startLine: 4
-      suppressionType: 'current'
+      startLine: 5
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
+          column: 26
+          index: 57
           line: 4
         }
         start: Object {
           column: 0
-          index: 0
+          index: 31
           line: 4
         }
       }
     }
     Object {
-      category: 'dog'
-      endLine: 4
+      category: 'yes'
+      endLine: 10
       filename: 'unknown'
-      startLine: 4
-      suppressionType: 'current'
+      startLine: 10
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 4
+          column: 3
+          index: 97
+          line: 9
         }
         start: Object {
           column: 0
-          index: 0
-          line: 4
+          index: 66
+          line: 7
+        }
+      }
+    }
+    Object {
+      category: 'frog'
+      endLine: 10
+      filename: 'unknown'
+      startLine: 10
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 3
+          index: 97
+          line: 9
+        }
+        start: Object {
+          column: 0
+          index: 66
+          line: 7
+        }
+      }
+    }
+    Object {
+      category: 'wow'
+      endLine: 16
+      filename: 'unknown'
+      startLine: 16
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 3
+          index: 146
+          line: 15
+        }
+        start: Object {
+          column: 0
+          index: 106
+          line: 12
+        }
+      }
+    }
+    Object {
+      category: 'fish'
+      endLine: 16
+      filename: 'unknown'
+      startLine: 16
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 3
+          index: 146
+          line: 15
+        }
+        start: Object {
+          column: 0
+          index: 106
+          line: 12
         }
       }
     }
@@ -270,81 +278,77 @@ Object {
   suppressions: Array [
     Object {
       category: 'foo'
-      endLine: 1
-      filename: 'unknown'
-      startLine: 1
-      suppressionType: 'current'
-      commentLocation: Object {
-        filename: 'unknown'
-        end: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-        start: Object {
-          column: 0
-          index: 0
-          line: 1
-        }
-      }
-    }
-    Object {
-      category: 'foo'
       endLine: 2
       filename: 'unknown'
       startLine: 2
-      suppressionType: 'current'
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 2
+          column: 18
+          index: 18
+          line: 1
         }
         start: Object {
           column: 0
           index: 0
-          line: 2
+          line: 1
         }
       }
     }
     Object {
-      category: 'foo'
-      endLine: 3
+      category: 'bar'
+      endLine: 5
       filename: 'unknown'
-      startLine: 3
-      suppressionType: 'current'
+      startLine: 5
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 3
+          column: 22
+          index: 49
+          line: 4
         }
         start: Object {
           column: 0
-          index: 0
-          line: 3
+          index: 27
+          line: 4
         }
       }
     }
     Object {
-      category: 'foo'
-      endLine: 4
+      category: 'yes'
+      endLine: 10
       filename: 'unknown'
-      startLine: 4
-      suppressionType: 'current'
+      startLine: 10
       commentLocation: Object {
         filename: 'unknown'
         end: Object {
-          column: 0
-          index: 0
-          line: 4
+          column: 3
+          index: 84
+          line: 9
         }
         start: Object {
           column: 0
-          index: 0
-          line: 4
+          index: 58
+          line: 7
+        }
+      }
+    }
+    Object {
+      category: 'wow'
+      endLine: 16
+      filename: 'unknown'
+      startLine: 16
+      commentLocation: Object {
+        filename: 'unknown'
+        end: Object {
+          column: 3
+          index: 128
+          line: 15
+        }
+        start: Object {
+          column: 0
+          index: 93
+          line: 12
         }
       }
     }

--- a/packages/@romejs/js-formatter/builders/index.ts
+++ b/packages/@romejs/js-formatter/builders/index.ts
@@ -7,7 +7,7 @@
 
 import {BuilderMethod} from '../Builder';
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 const builders: Map<string, BuilderMethod<any>> = new Map();
 
 export default builders;

--- a/packages/@romejs/js-formatter/node/parentheses.ts
+++ b/packages/@romejs/js-formatter/node/parentheses.ts
@@ -46,7 +46,7 @@ function isClassExtendsClause(node: AnyNode, parent: AnyNode): boolean {
 const parens: Map<
   AnyNode['type'],
   (
-    // rome-ignore-next-line lint/noExplicitAny
+    // rome-ignore lint/noExplicitAny
     node: any,
     parent: AnyNode,
     printStack: Array<AnyNode>,

--- a/packages/@romejs/js-parser/parser.ts
+++ b/packages/@romejs/js-parser/parser.ts
@@ -94,7 +94,7 @@ const SCOPE_TYPES: Array<ScopeType> = [
 ];
 
 const createJSParser = createParser((ParserCore, ParserWithRequiredPath) => {
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   class JSParser extends ParserWithRequiredPath<any, State> {
     constructor(options: JSParserOptions) {
       const state = createInitialState();

--- a/packages/@romejs/node/index.ts
+++ b/packages/@romejs/node/index.ts
@@ -9,7 +9,7 @@ import mod = require('module');
 
 import {AbsoluteFilePath, AbsoluteFilePathMap, CWD_PATH} from '@romejs/path';
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 type RequireFunction = (name: string) => any;
 
 const requires: AbsoluteFilePathMap<RequireFunction> = new AbsoluteFilePathMap();
@@ -28,7 +28,7 @@ function getRequire(folder: AbsoluteFilePath = CWD_PATH): RequireFunction {
   return req;
 }
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export function requireGlobal(name: string, folder?: AbsoluteFilePath): any {
   return getRequire(folder)(name);
 }

--- a/packages/@romejs/pretty-format/index.ts
+++ b/packages/@romejs/pretty-format/index.ts
@@ -175,7 +175,7 @@ function formatFunction(val: Function, opts: FormatOptions): string {
     return label;
   }
 
-  // rome-ignore-next-line lint/noExplicitAny
+  // rome-ignore lint/noExplicitAny
   return formatObject(label, (val as any), opts, []);
 }
 

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -93,20 +93,21 @@ export type ProjectConfigJSON = ProjectConfigJSONObjectReducer<ProjectConfigBase
 };
 
 // Weird way to get the value type from a map
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 type MapValue<T extends Map<string, any>> = NonNullable<ReturnType<T['get']>>;
 
 // Turn any file paths into strings
 // Turn maps into objects
 // TODO maybe add path patterns
+// rome-ignore lint/noExplicitAny
 type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
   ? string
   : Type extends Array<AbsoluteFilePath>
     ? Array<string>
     : Type extends AbsoluteFilePathSet
-      ? Array<string> // rome-ignore-next-line lint/noExplicitAny
+      ? Array<string>
       : Type extends Map<string, any>
-        ? Dict<MapValue<Type>> // rome-ignore-next-line lint/noExplicitAny
+        ? Dict<MapValue<Type>>
         : Type extends Dict<any>
           ? ProjectConfigJSONObjectReducer<Type>
           : Type;
@@ -131,7 +132,7 @@ export type PartialProjectConfig = Partial<ProjectConfigBase> & {
   >
 };
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 type PartialProjectValue<Type> = Type extends Map<string, any>
   ? Type
   : Partial<Type>;

--- a/packages/@romejs/typescript-helpers/index.ts
+++ b/packages/@romejs/typescript-helpers/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// rome-ignore-next-line lint/noExplicitAny
+// rome-ignore lint/noExplicitAny
 export type Class<T, Args extends Array<unknown> = Array<any>> = {
   new (
     ...args: Args


### PR DESCRIPTION
This PR removes all the previous suppression types. There's now only one suppression comment type. It's name is `rome-ignore`.

`rome-ignore` will take the next "node" and use it's range as the target for suppression. It can suppress multiple diagnostics. It must suppress at least one diagnostic or it will error.

After thinking about it more, there isn't a ton of value in having "rome-ignore-next-line`, or even `rome-ignore-current-line` when the new `rome-ignore` is more flexible, and should reduce the amount of possibilities wherever we can.

I was initially worried about #371 where I said:

> This PR also implements rome-ignore-next-statement that takes the range of the node it's attached to and suppresses everything within it. I'm not 100% sure how I feel about this. It feels very easily abused, or could even accidentally hide new errors unintentionally. We should have a good story if it's actually worth it. If the goal is to make it easier on the developer in the event of formatting causing newlines, then we should invest in some logic to automatically move or add suppressions rather than offering this capability.

But my fear is probably unfounded. This will make it easier for people to adopt Rome too as suppression comments are easy and the only way since we will not have configuration.