### PR TITLE
Keep empty lines when formatting nodes

### DIFF
--- a/packages/@romejs/core/master/commands/test.ts
+++ b/packages/@romejs/core/master/commands/test.ts
@@ -42,6 +42,7 @@ export default createMasterCommand({
               `${path.getExtensionlessBasename()}.test${path.getExtensions()}`,
             )
       ,
+
       test: (path) => path.hasExtension('test'),
       noun: 'test',
       verb: 'testing',

--- a/packages/@romejs/js-formatter/builders/expressions/ArrayExpression.ts
+++ b/packages/@romejs/js-formatter/builders/expressions/ArrayExpression.ts
@@ -16,7 +16,6 @@ import {
   Token,
   concat,
   group,
-  hardline,
   ifBreak,
   indent,
   join,
@@ -37,12 +36,9 @@ export default function ArrayExpression(
 
   if (!hasContents && !hasRest) {
     if (hasInnerComments(node)) {
-      return concat([
-        '[',
-        builder.tokenizeInnerComments(node, true),
-        hardline,
-        ']',
-      ]);
+      return group(
+        concat(['[', builder.tokenizeInnerComments(node, true), softline, ']']),
+      );
     } else {
       return '[]';
     }
@@ -53,11 +49,14 @@ export default function ArrayExpression(
   if (hasContents) {
     const elements: Array<Token> = [];
 
-    for (const element of node.elements) {
-      if (element === undefined) {
-        elements.push('');
+    for (let i = 0; i < node.elements.length; i++) {
+      const element = node.elements[i];
+      const printed = builder.tokenize(element, node);
+
+      if (i > 0 && builder.getLinesBetween(node.elements[i - 1], element) > 1) {
+        elements.push(concat([softline, printed]));
       } else {
-        elements.push(builder.tokenize(element, node));
+        elements.push(printed);
       }
     }
 

--- a/packages/@romejs/js-formatter/builders/utils.ts
+++ b/packages/@romejs/js-formatter/builders/utils.ts
@@ -165,6 +165,12 @@ export function printTSBraced(
   node: AnyNode,
   members: Array<AnyNode>,
 ): Token {
+  if (members.length === 0) {
+    return group(
+      concat(['{', builder.tokenizeInnerComments(node, true), softline, '}']),
+    );
+  }
+
   return group(
     concat([
       '{',
@@ -173,7 +179,17 @@ export function printTSBraced(
           hardline,
           join(
             hardline,
-            members.map((member) => builder.tokenize(member, node)),
+            members.map((member, index) => {
+              const printed = builder.tokenize(member, node);
+              if (
+                index > 0 &&
+                builder.getLinesBetween(members[index - 1], member) > 1
+              ) {
+                return concat([hardline, printed]);
+              } else {
+                return printed;
+              }
+            }),
           ),
         ]),
       ),

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -33,15 +33,9 @@ export type ProjectDefinition = {
 
 // Project config objects to categorize settings
 export type ProjectConfigObjects = {
-  cache: {
-
-  };
-  resolver: {
-
-  };
-  compiler: {
-
-  };
+  cache: {};
+  resolver: {};
+  compiler: {};
   bundler: {
     mode: BundlerMode;
   };

--- a/packages/@romejs/string-diff/index.ts
+++ b/packages/@romejs/string-diff/index.ts
@@ -229,8 +229,8 @@ function bisect(text1: string, text2: string): Diffs {
   let vLength = 2 * maxD;
   let v1 = new Array(vLength);
   let v2 = new Array(vLength);
-  // Setting all elements to -1 is faster in Chrome & Firefox than mixing
 
+  // Setting all elements to -1 is faster in Chrome & Firefox than mixing
   // integers and undefined.
   for (let x = 0; x < vLength; x++) {
     v1[x] = -1;
@@ -239,12 +239,12 @@ function bisect(text1: string, text2: string): Diffs {
   v1[vOffset + 1] = 0;
   v2[vOffset + 1] = 0;
   let delta = text1Length - text2Length;
-  // If the total number of characters is odd, then the front path will collide
 
+  // If the total number of characters is odd, then the front path will collide
   // with the reverse path.
   let front = delta % 2 !== 0;
-  // Offsets for start and end of k loop.
 
+  // Offsets for start and end of k loop.
   // Prevents mapping of space beyond the grid.
   let k1Start = 0;
   let k1End = 0;
@@ -330,8 +330,8 @@ function bisect(text1: string, text2: string): Diffs {
       }
     }
   }
-  // Diff took too long and hit the deadline or
 
+  // Diff took too long and hit the deadline or
   // number of diffs equals number of characters, no commonality at all.
   return [[DIFF_DELETE, text1], [DIFF_INSERT, text2]];
 }
@@ -372,7 +372,6 @@ function commonPrefix(text1: string, text2: string): number {
   }
 
   // Binary search.
-
   // Performance analysis: http://neil.fraser.name/news/2007/10/09/
   let pointermin = 0;
   let pointermax = Math.min(text1.length, text2.length);
@@ -714,18 +713,17 @@ function cleanupMerge(diffs: Diffs, fixUnicode: boolean) {
     }
   }
   if (diffs[diffs.length - 1][1] === '') {
-    diffs.pop(); // Remove the dummy entry at the end.
+    // Remove the dummy entry at the end.
+    diffs.pop();
   }
 
   // Second pass: look for single edits surrounded on both sides by equalities
-
   // which can be shifted sideways to eliminate an equality.
-
   // e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
   let changes = false;
   pointer = 1;
-  // Intentionally ignore the first and last element (don't need checking).
 
+  // Intentionally ignore the first and last element (don't need checking).
   while (pointer < diffs.length - 1) {
     if (
       diffs[pointer - 1][0] === DIFF_EQUAL &&
@@ -763,8 +761,8 @@ function cleanupMerge(diffs: Diffs, fixUnicode: boolean) {
     }
     pointer++;
   }
-  // If shifts were made, the diff needs reordering and another shift sweep.
 
+  // If shifts were made, the diff needs reordering and another shift sweep.
   if (changes) {
     cleanupMerge(diffs, fixUnicode);
   }

--- a/packages/@romejs/typescript-helpers/index.ts
+++ b/packages/@romejs/typescript-helpers/index.ts
@@ -25,9 +25,7 @@ export type OptionalProps<Obj, Keys extends keyof Obj> = Omit<Obj, Keys> & {
 };
 
 // Turn a type that contains interfaces into regular objects
-export type InterfaceToObject<T> = T extends {
-
-}
+export type InterfaceToObject<T> = T extends {}
   ? {[K in keyof T]: InterfaceToObject<T[K]>}
   : T;
 


### PR DESCRIPTION
This PR inspects empty lines between nodes to keep them when it makes sense.
This change applies to:

- `ArrayExpression`
- `ObjectExpression`
- `TSInterfaceBody`
- `TSTypeLiteral`
- `TSEnumDeclaration`