### PR TITLE
Avoid strings if possible for inline snapshots

### DIFF
--- a/packages/@romejs/core/test-worker/TestAPI.ts
+++ b/packages/@romejs/core/test-worker/TestAPI.ts
@@ -575,22 +575,14 @@ export default class TestAPI implements TestHelper {
     }
   }
 
-  inlineSnapshot(received: unknown, snapshot?: string) {
+  inlineSnapshot(received: unknown, snapshot?: string | boolean | number) {
     const callFrame = getErrorStructure(new Error()).frames[1];
-
-    let formatted = '';
-    if (typeof received === 'string') {
-      formatted = received;
-    } else {
-      formatted = prettyFormat(received);
-    }
-
     const callError = getErrorStructure(new Error(), 1);
 
     this.onTeardown(async () => {
-      const status = this.snapshotManager.testInlineSnapshot(
+      const {status} = this.snapshotManager.testInlineSnapshot(
         callFrame,
-        formatted,
+        received,
         snapshot,
       );
 
@@ -609,7 +601,7 @@ export default class TestAPI implements TestHelper {
             ...callError,
             message: 'Inline snapshots do not match',
             advice: this.buildMatchAdvice(
-              formatted,
+              received,
               snapshot,
               {
                 receivedAlias: 'What the code gave us',

--- a/packages/@romejs/core/test-worker/utils.ts
+++ b/packages/@romejs/core/test-worker/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import prettyFormat from '@romejs/pretty-format';
+
+export function format(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  } else {
+    return prettyFormat(value);
+  }
+}

--- a/packages/@romejs/core/worker/WorkerAPI.ts
+++ b/packages/@romejs/core/worker/WorkerAPI.ts
@@ -6,7 +6,7 @@
  */
 
 import {FileReference, Worker} from '@romejs/core';
-import {AnyNode, Program, stringLiteral} from '@romejs/js-ast';
+import {AnyNode, Program} from '@romejs/js-ast';
 import {Diagnostics, catchDiagnostics, descriptions} from '@romejs/diagnostics';
 import {
   CompileResult,
@@ -38,7 +38,7 @@ import {
   InlineSnapshotUpdates,
 } from '../test-worker/SnapshotManager';
 import {formatJS} from '@romejs/js-formatter';
-import {getNodeReferenceParts} from '@romejs/js-ast-utils';
+import {getNodeReferenceParts, valueToNode} from '@romejs/js-ast-utils';
 
 // Some Windows git repos will automatically convert Unix line endings to Windows
 // This retains the line endings for the formatted code if they were present in the source
@@ -177,10 +177,7 @@ export default class WorkerAPI {
 
             return {
               ...node,
-              arguments: [
-                args[0],
-                stringLiteral.create({value: matchedUpdate.snapshot}),
-              ],
+              arguments: [args[0], valueToNode(matchedUpdate.snapshot)],
             };
           }
 

--- a/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
+++ b/packages/@romejs/diagnostics/DiagnosticsProcessor.ts
@@ -210,6 +210,10 @@ export default class DiagnosticsProcessor {
   }
 
   buildDedupeKeys(diag: Diagnostic): Array<string> {
+    if (diag.unique) {
+      return [];
+    }
+
     // We don't do anything with `end` in this method, it's fairly meaningless for deduping errors
     let {start} = diag.location;
 

--- a/packages/@romejs/diagnostics/types.ts
+++ b/packages/@romejs/diagnostics/types.ts
@@ -63,6 +63,7 @@ export type DiagnosticSourceType = 'unknown' | ConstSourceType;
 export type Diagnostic = {
   description: DiagnosticDescription;
   location: DiagnosticLocation;
+  unique?: boolean;
   fixable?: boolean;
   label?: string;
   origins?: Array<DiagnosticOrigin>;

--- a/packages/@romejs/js-ast-utils/createMemberProperty.ts
+++ b/packages/@romejs/js-ast-utils/createMemberProperty.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  ComputedMemberProperty,
+  StaticMemberProperty,
+  computedMemberProperty,
+  identifier,
+  staticMemberProperty,
+  stringLiteral,
+} from '@romejs/js-ast';
+import isValidIdentifierName from './isValidIdentifierName';
+
+export default function createMemberProperty(
+  name: string,
+): StaticMemberProperty | ComputedMemberProperty {
+  if (isValidIdentifierName(name)) {
+    return staticMemberProperty.quick(identifier.quick(name));
+  } else {
+    return computedMemberProperty.quick(stringLiteral.quick(name));
+  }
+}

--- a/packages/@romejs/js-ast-utils/createPropertyKey.ts
+++ b/packages/@romejs/js-ast-utils/createPropertyKey.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import isValidIdentifierName from './isValidIdentifierName';
+import {
+  Identifier,
+  StringLiteral,
+  identifier,
+  stringLiteral,
+} from '@romejs/js-ast';
+
+export default function createPropertyKey(
+  name: string,
+): Identifier | StringLiteral {
+  if (isValidIdentifierName(name)) {
+    return identifier.quick(name);
+  } else {
+    return stringLiteral.quick(name);
+  }
+}

--- a/packages/@romejs/js-ast-utils/doesNodeMatchPattern.test.ts
+++ b/packages/@romejs/js-ast-utils/doesNodeMatchPattern.test.ts
@@ -14,32 +14,32 @@ test(
   (t) => {
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`foo`, 'foo'),
-      'true',
+      true,
     );
 
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`this.foo`, 'this.foo'),
-      'true',
+      true,
     );
 
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`exports.foo`, 'exports.**'),
-      'true',
+      true,
     );
 
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`this.foo.bar`, 'this.foo.*'),
-      'true',
+      true,
     );
 
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`this.foo.bar.yes`, 'this.foo.*'),
-      'false',
+      false,
     );
 
     t.inlineSnapshot(
       doesNodeMatchPattern(template.expression`this.foo.bar.yes`, 'this.foo.**'),
-      'true',
+      true,
     );
   },
 );

--- a/packages/@romejs/js-ast-utils/index.ts
+++ b/packages/@romejs/js-ast-utils/index.ts
@@ -35,3 +35,6 @@ export {default as removeLoc} from './removeLoc';
 export {default as removeShallowLoc} from './removeShallowLoc';
 export {default as renameBindings} from './renameBindings';
 export {default as template} from './template';
+export {default as valueToNode} from './valueToNode';
+export {default as createPropertyKey} from './createPropertyKey';
+export {default as createMemberProperty} from './createMemberProperty';

--- a/packages/@romejs/js-ast-utils/valueToNode.ts
+++ b/packages/@romejs/js-ast-utils/valueToNode.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  ArrayExpression,
+  BooleanLiteral,
+  NullLiteral,
+  NumericLiteral,
+  ObjectExpression,
+  ObjectProperty,
+  ReferenceIdentifier,
+  StringLiteral,
+  arrayExpression,
+  booleanLiteral,
+  nullLiteral,
+  numericLiteral,
+  objectExpression,
+  objectProperty,
+  referenceIdentifier,
+  staticPropertyKey,
+  stringLiteral,
+} from '@romejs/js-ast';
+import createPropertyKey from './createPropertyKey';
+import {UnknownObject} from '@romejs/typescript-helpers';
+
+export default function valueToNode(
+  value: unknown,
+  ancestry: Array<unknown> = [],
+):
+  | StringLiteral
+  | BooleanLiteral
+  | NumericLiteral
+  | ObjectExpression
+  | NullLiteral
+  | ReferenceIdentifier
+  | ArrayExpression {
+  if (ancestry.includes(value)) {
+    throw new Error('Recursion detected');
+  }
+
+  switch (typeof value) {
+    case 'string':
+      return stringLiteral.quick(value);
+
+    case 'boolean':
+      return booleanLiteral.quick(value);
+
+    case 'number':
+      return numericLiteral.quick(value);
+
+    case 'undefined':
+      return referenceIdentifier.quick('undefined');
+
+    case 'object': {
+      if (value === null) {
+        return nullLiteral.create({});
+      }
+
+      const subAncestry = [...ancestry, value];
+
+      if (Array.isArray(value)) {
+        return arrayExpression.quick(
+          value.map((elem) => valueToNode(elem, subAncestry)),
+        );
+      }
+
+      const obj = (value as UnknownObject);
+      const props: Array<ObjectProperty> = [];
+
+      for (let key in obj) {
+        props.push(
+          objectProperty.create({
+            key: staticPropertyKey.create({
+              value: createPropertyKey(key),
+            }),
+            value: valueToNode(obj[key], subAncestry),
+          }),
+        );
+      }
+
+      return objectExpression.quick(props);
+    }
+
+    default:
+      throw new Error('Do not know how to turn this value into a literal');
+  }
+}

--- a/packages/@romejs/js-ast/literals/NumericLiteral.ts
+++ b/packages/@romejs/js-ast/literals/NumericLiteral.ts
@@ -6,7 +6,7 @@
  */
 
 import {JSNodeBase} from '../index';
-import {createBuilder} from '../utils';
+import {createQuickBuilder} from '../utils';
 
 export type NumericLiteral = JSNodeBase & {
   type: 'NumericLiteral';
@@ -14,8 +14,9 @@ export type NumericLiteral = JSNodeBase & {
   format?: 'octal' | 'binary' | 'hex';
 };
 
-export const numericLiteral = createBuilder<NumericLiteral>(
+export const numericLiteral = createQuickBuilder<NumericLiteral, 'value'>(
   'NumericLiteral',
+  'value',
   {
     bindingKeys: {},
     visitorKeys: {},

--- a/packages/@romejs/js-ast/utils.ts
+++ b/packages/@romejs/js-ast/utils.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {assertSingleNode, inheritLoc} from '@romejs/js-ast-utils';
 import {NodeBase} from '@romejs/parser-core';
 import {AnyNode} from './index';
-import {assertSingleNode, inheritLoc} from '@romejs/js-ast-utils';
 import {JSNodeBase} from './base';
 import {TransformExitResult} from '@romejs/js-compiler';
 


### PR DESCRIPTION
If the `received` value is a boolean, number, null, or undefined, then we just reconstruct it instead of the formatted string.